### PR TITLE
Update README.md for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ pip install modelscope torchaudio sentencepiece funasr
 
 ```bash
 sudo apt install ffmpeg
+sudo apt install libsox-dev
+conda install -c conda-forge 'ffmpeg<7'
 ```
 
 #### MacOS Users


### PR DESCRIPTION
Ubuntu 22.04 LTS
reported: 
 >>> OSError: libsox.so: cannot open shared object file: No such file or directory
>>> RuntimeError: Error in dlopen: libavutil.so.58: cannot open shared object file: No such file or directory
>>> DEBUG:torchaudio._extension.utils:Attempting to load FFmpeg version 6, 5, 4. not found