### PR TITLE
solve pyopenjtalk issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,19 +34,19 @@ https://github.com/RVC-Boss/GPT-SoVITS/assets/129054828/05bee1fa-bdd8-4d85-9350-
 
 ## Requirements (How to Install)
 
-### Visual Studio Enterprise 2017 (for windows)
-Before installing this project, please check if you have Visual studio Enterprise 2017, as version 2022 will cause issues with pyopenjtalk. If you dont have it installed, you can subscribe to **Visual Studio Dev Essentials**(free) by clicking [here](https://my.visualstudio.com/Subscriptions).
+### Visual Studio Enterprise 2017 (Windows)
+Before installing this project, please check if you have **Visual studio Enterprise 2017**, as version 2022 will cause issues with pyopenjtalk. If you dont have it installed, you can subscribe to **Visual Studio Dev Essentials** (free) by clicking [here](https://my.visualstudio.com/Subscriptions).
 
-Then, install Visual Studio Enterprise 2017 by clicking[here](https://my.visualstudio.com/Downloads?q=Visual%20Studio%202017), choose the top one that says **Visual Studio Enterprise 2017** and click **Download**. Finally, follow the instructions to install Visual Studio Enterprise 2017 on your windows computer.
+Then, install **Visual Studio Enterprise** 2017 by clicking [here](https://my.visualstudio.com/Downloads?q=Visual%20Studio%202017), choose the top one that says **Visual Studio Enterprise 2017** and click **Download**. Finally, follow the instructions to install Visual Studio Enterprise 2017 on your windows computer.
 
 ### Add cmake and hostx64 into *Path* in System Environment Variables
-Please add these two file directories into **Path** in System Environment Variables (type environment in Windows search bar, click '**Edit the system environment variables**', then click **Environment Variables**
-```bash
+Please add these two file directories into **Path** in System Environment Variables (type environment in Windows search bar, click '**Edit the system environment variables**', then click **Environment Variables**)
+```
 {Your path for VS 2017}\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin
 {Your path for VS 2017}\VC\Tools\MSVC\14.16.27023\bin\Hostx64\x64
 ```
 
-**Special thanks to YulKe on CSDN in providing [this tutorial](https://blog.csdn.net/weixin_42033112/article/details/133427964).
+**Special thanks to YulKe on CSDN in providing [this tutorial](https://blog.csdn.net/weixin_42033112/article/details/133427964).**
 
 
 ### Python and PyTorch Version


### PR DESCRIPTION
Added the instructions for installing Visual Studio 2017 Enterprise and add cmake and hostx64 into paths for system environment variables as vs 2022 will cause issues with pyopenjtalk.

添加安装 VS2017 企业版并配置系统环境变量的教程，因为pyopenjtalk 在 vs 2022版上根本安装不了一点