### PR TITLE
Fixed i18n error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ sentencepiece
 transformers
 chardet
 PyYAML
+i18n


### PR DESCRIPTION
Line 27 of webui.py contains an import from i18n.i18n but there was no module in the requirements.
I added the module i18n.

Line for context: "from i18n.i18n import I18nAuto"