### PR TITLE
Disable debug level logging

### DIFF
--- a/GPT_SoVITS/utils.py
+++ b/GPT_SoVITS/utils.py
@@ -18,7 +18,7 @@ logging.getLogger("matplotlib").setLevel(logging.ERROR)
 
 MATPLOTLIB_FLAG = False
 
-logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+logging.basicConfig(stream=sys.stdout, level=logging.WARNING)
 logger = logging
 
 
@@ -310,13 +310,13 @@ def check_git_hash(model_dir):
 def get_logger(model_dir, filename="train.log"):
     global logger
     logger = logging.getLogger(os.path.basename(model_dir))
-    logger.setLevel(logging.DEBUG)
+    logger.setLevel(logging.WARNING)
 
     formatter = logging.Formatter("%(asctime)s\t%(name)s\t%(levelname)s\t%(message)s")
     if not os.path.exists(model_dir):
         os.makedirs(model_dir)
     h = logging.FileHandler(os.path.join(model_dir, filename))
-    h.setLevel(logging.DEBUG)
+    h.setLevel(logging.WARNING)
     h.setFormatter(formatter)
     logger.addHandler(h)
     return logger


### PR DESCRIPTION
When using `inference_webui.py`, it produces debug level info for http requests, for example: 
```
DEBUG:httpcore.http11:response_closed.started
```
Here I changed it to warning level.