### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ conda activate GPTSoVits
 bash install.sh
 ```
 ### Install Manually
+#### Make sure you have the distutils for python3.9 installed
+
+```bash
+sudo apt-get install python3.9-distutils
+```
+
 #### Pip Packages
 
 ```bash


### PR DESCRIPTION
fixes #88:
Some users were facing problems while installing the PIP packages because distutils.cmd module was missing in their Python environment.
