### PR TITLE
Fix Bugs in uvr5 usage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy==1.23.5
 scipy
 tensorboard
 librosa==0.9.2

--- a/tools/uvr5/webui.py
+++ b/tools/uvr5/webui.py
@@ -47,7 +47,7 @@ def uvr(model_name, inp_root, save_root_vocal, paths, save_root_ins, agg, format
             )
         is_hp3 = "HP3" in model_name
         if inp_root != "":
-            paths = [os.path.join(inp_root, name) for name in os.listdir(inp_root)]
+            paths = [name for name in os.listdir(inp_root)]
         else:
             paths = [path.name for path in paths]
         for path in paths:


### PR DESCRIPTION
修复了2个关于uvr5的问题
1. 当前实现由于使用librosa.core.load方法，因此强依赖librosa==0.9.2，但此库使用的numpy.float是最新版numpy不支持的。因此需要限定numpy==1.23.5
2. tools/uvr5/webui.py中，50行和54重复进行了`os.path.join`导致路径错误