### PR TITLE
Fix "AttributeError: module 'torch' has no attribute 'mps'" in api.py while running on non-Apple platform

### DIFF
--- a/api.py
+++ b/api.py
@@ -439,7 +439,8 @@ def handle(refer_wav_path, prompt_text, prompt_language, text, text_language):
     wav.seek(0)
 
     torch.cuda.empty_cache()
-    torch.mps.empty_cache()
+    if device == "mps":
+        torch.mps.empty_cache()
     return StreamingResponse(wav, media_type="audio/wav")
 
 

--- a/api.py
+++ b/api.py
@@ -104,8 +104,13 @@ RESP: 无
 
 import argparse
 import os
-import signal
 import sys
+
+now_dir = os.getcwd()
+sys.path.append(now_dir)
+sys.path.append("%s/GPT_SoVITS" % (now_dir))
+
+import signal
 from time import time as ttime
 import torch
 import librosa
@@ -440,6 +445,7 @@ def handle(refer_wav_path, prompt_text, prompt_language, text, text_language):
 
     torch.cuda.empty_cache()
     if device == "mps":
+        print('executed torch.mps.empty_cache()')
         torch.mps.empty_cache()
     return StreamingResponse(wav, media_type="audio/wav")
 


### PR DESCRIPTION
While I'm testing on both my GTX 1060 platform and E5-2678 v3 server, I noticed such a sort of error message. Since MPS device is only for Apple platforms, this method shouldn't be invoked if api server is running on other platforms. Besides, I have no experience with Artificial Intelligence development and I'm just a junior high school student in China Mainland, so if there's any issue with this pr, please edit the code by yourselves. : -)
```
INFO:     1.1.1.1:0 - "GET /?text=Hey+there!&text_language=en HTTP/1.1" 500 Internal Server Error
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "F:\GPT-SoVITS-beta0128\runtime\lib\site-packages\uvicorn\protocols\http\h11_impl.py", line 407, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
  File "F:\GPT-SoVITS-beta0128\runtime\lib\site-packages\uvicorn\middleware\proxy_headers.py", line 78, in __call__
    return await self.app(scope, receive, send)
  File "F:\GPT-SoVITS-beta0128\runtime\lib\site-packages\fastapi\applications.py", line 270, in __call__
    await super().__call__(scope, receive, send)
  File "F:\GPT-SoVITS-beta0128\runtime\lib\site-packages\starlette\applications.py", line 124, in __call__
    await self.middleware_stack(scope, receive, send)
  File "F:\GPT-SoVITS-beta0128\runtime\lib\site-packages\starlette\middleware\errors.py", line 184, in __call__
    raise exc
  File "F:\GPT-SoVITS-beta0128\runtime\lib\site-packages\starlette\middleware\errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "F:\GPT-SoVITS-beta0128\runtime\lib\site-packages\starlette\middleware\exceptions.py", line 79, in __call__
    raise exc
  File "F:\GPT-SoVITS-beta0128\runtime\lib\site-packages\starlette\middleware\exceptions.py", line 68, in __call__
    await self.app(scope, receive, sender)
  File "F:\GPT-SoVITS-beta0128\runtime\lib\site-packages\fastapi\middleware\asyncexitstack.py", line 21, in __call__
    raise e
  File "F:\GPT-SoVITS-beta0128\runtime\lib\site-packages\fastapi\middleware\asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "F:\GPT-SoVITS-beta0128\runtime\lib\site-packages\starlette\routing.py", line 706, in __call__
    await route.handle(scope, receive, send)
  File "F:\GPT-SoVITS-beta0128\runtime\lib\site-packages\starlette\routing.py", line 276, in handle
    await self.app(scope, receive, send)
  File "F:\GPT-SoVITS-beta0128\runtime\lib\site-packages\starlette\routing.py", line 66, in app
    response = await func(request)
  File "F:\GPT-SoVITS-beta0128\runtime\lib\site-packages\fastapi\routing.py", line 235, in app
    raw_response = await run_endpoint_function(
  File "F:\GPT-SoVITS-beta0128\runtime\lib\site-packages\fastapi\routing.py", line 161, in run_endpoint_function
    return await dependant.call(**values)
  File "F:\GPT-SoVITS-beta0128\api.py", line 500, in tts_endpoint
    return handle(refer_wav_path, prompt_text, prompt_language, text, text_language)
  File "F:\GPT-SoVITS-beta0128\api.py", line 443, in handle
    torch.mps.empty_cache()
AttributeError: module 'torch' has no attribute 'mps'
```