### PR TITLE
Use TTSFRD process text

### DIFF
--- a/GPT_SoVITS/text/cleaner.py
+++ b/GPT_SoVITS/text/cleaner.py
@@ -1,4 +1,221 @@
 from text import chinese, japanese, cleaned_text_to_sequence, symbols, english
+import ttsfrd
+import re,os,zipfile,requests
+
+ENG_LANG_MAPPING = {
+    "PinYin": "zh-cn",
+    "English": "en-us",
+    "British": "en-gb",
+    "ZhHK": "hk_cantonese",
+    "Sichuan": "sichuan",
+    "Japanese": "japanese",
+    "WuuShangHai": "shanghai",
+    "Indonesian": "indonesian",
+    "Malay": "malay",
+    "Filipino": "filipino",
+    "Vietnamese": "vietnamese",
+    "Korean": "korean",
+    "Russian": "russian",
+}
+
+chinese_dict = {
+    "xx":"x",
+    "uei":"ui",
+    "ii":"i0",
+    "ih":"ir",
+    "uen":"un",
+    "iou":"iu",
+    "angr":"ang",
+    "anr":"an",
+    "aor":"ao",
+    "ar":"a",
+    "eir":"ei",
+    "engr":"eng",
+    "enr":"en",
+    "ianr":"ian",
+    "iaor":"iao",
+    "ingr":"ing",
+    "or":"o",
+    "ur":"u",
+    "ihr":"ih",
+    "ongr":"ong",
+    "our":"ou",
+    "uangr":"uang",
+    "uanr":"uan",
+    "ueir":"uei",
+    "uenr":"uen",
+    "uor":"uo",
+    "iir":"ii",
+    "air":"ai",
+    "ier":"ie",
+    "uair":"uai",
+    "uar":"ua",
+    "iar":"ia",
+    "inr":"in",
+    "iour":"iou",
+    "vanr":"van",
+    "ver":"ve",
+    "vnr":"vn",
+    "iangr":"iang",
+    "vr":"v",
+    "iongr":"iong",
+}
+english_dict = {
+    "DH1":"DH",
+    "NG0":"NG",
+    "SH0":"SH",
+    "NG1":"NG",
+    "CH0":"CH",
+    "HH0":"HH",
+    "ZH0":"ZH",
+    "HH1":"HH",
+    "SH1":"SH",
+    "ZH1":"ZH",
+    "DH0":"DH",
+    "TH1":"TH",
+    "CH1":"CH",
+    "JH1":"JH",
+    "JH0":"JH",
+    "NG2":"NG",
+    "TH0":"TH",
+}
+japanese_dict = {
+    "nn":"N",
+    "ux":"U",
+    "ix":"I",
+}
+
+resource_dir = "GPT_SoVITS/text/resource"
+resources_zip_file = "GPT_SoVITS/text/resource.zip"
+if not os.path.exists(resource_dir):
+    if not os.path.exists(resources_zip_file):
+        print("Downloading ttsfrd resources...")
+        modelscope_url = "https://www.modelscope.cn/api/v1/models/speech_tts/speech_kantts_ttsfrd/repo?Revision=v0.0.1&FilePath=resource.zip"
+        with requests.get(modelscope_url, stream=True) as r:
+            r.raise_for_status()
+            with open(resources_zip_file, 'wb') as f:
+                for chunk in r.iter_content(chunk_size=8192):
+                    if chunk:
+                        f.write(chunk)
+    
+    print("Extracting ttsfrd resources...")
+    with zipfile.ZipFile(resources_zip_file, "r") as zip_ref:
+        zip_ref.extractall("GPT_SoVITS/text")
+
+fe = ttsfrd.TtsFrontendEngine()
+assert fe.initialize(resource_dir),"Check ttsfrd resource"
+
+def clean_text(text, language):
+    if(language not in language_module_map):
+        language="en"
+        text=" "
+    if language == "zh":
+        phones = []
+        word2ph = []
+        count = 0
+        fe.set_lang_type(ENG_LANG_MAPPING["PinYin"])
+        res = fe.gen_tacotron_symbols(text)
+        matches = re.findall(r'\{(.*?)\}', res)
+        for match in matches:
+            elements = match.split("$")
+            if elements[2] == "s_none":
+                if elements[0] == "#4":
+                    phone = "."
+                    phones += [phone]
+                    word2ph.append(1)
+                    continue
+                if elements[0] == "#3":
+                    phone = ","
+                    phones += [phone]
+                    word2ph.append(1)
+                continue
+
+            # Chinese
+            if elements[0] == "ga":
+                phone = "AA"
+                phones += [phone]
+                count += 1
+                continue
+            if elements[0] == "ge":
+                phone = "EE"
+                phones += [phone]
+                count += 1
+                continue
+            if elements[0] == "go":
+                phone = "OO"
+                phones += [phone]
+                count += 1
+                continue
+            if "_c" in elements[0]:
+                if elements[2] in ("s_begin","s_middle","s_both","s_end"):
+                    phone = elements[0].replace("_c", "")
+                    phone = chinese_dict.get(phone, phone)
+                    phone = chinese_dict.get(phone, phone)
+                    count += 1
+                    if elements[2] == "s_end":
+                        phone += elements[1].replace("tone", "")
+                        word2ph.append(count)
+                        count = 0
+                    phones += [phone]
+                    continue
+
+            # English
+            else:
+                if elements[2] in ("s_begin","s_middle","s_both","s_end"):
+                    phone = elements[0].upper()
+                    if len(elements[0]) > 1 :
+                        phone += elements[1].replace("tone", "")
+                    phone = english_dict.get(phone, phone)
+                phones += [phone]
+                continue
+    elif language == "en":
+        phones = []
+        word2ph = None
+        fe.set_lang_type(ENG_LANG_MAPPING["English"])
+        res = fe.gen_tacotron_symbols(text)
+        matches = re.findall(r'\{(.*?)\}', res)
+        for match in matches:
+            elements = match.split("$")
+            if elements[2] == "s_none":
+                if elements[0] == "#4":
+                    phone = "."
+                    phones += [phone]
+                continue
+
+            if elements[2] in ("s_begin","s_middle","s_both","s_end"):
+                phone = elements[0].upper()
+                if len(elements[0]) > 1 :
+                    phone += elements[1].replace("tone", "")
+                phone = english_dict.get(phone, phone)
+            phones += [phone]
+            continue
+    elif language == "ja":
+        phones = []
+        word2ph = None
+        fe.set_lang_type(ENG_LANG_MAPPING["Japanese"])
+        res = fe.gen_tacotron_symbols(text)
+        matches = re.findall(r'\{(.*?)\}', res)
+        for match in matches:
+            elements = match.split("$")
+            if elements[2] == "s_none":
+                if elements[0] == "#4":
+                    phone = "."
+                    phones += [phone]
+                    continue
+                if elements[0] == "#3":
+                    phone = ","
+                    phones += [phone]
+                continue
+            
+            if elements[2] in ("s_begin","s_middle","s_both","s_end"):
+                phone = elements[0]
+                phone = japanese_dict.get(phone, phone)
+            phones += [phone]
+            continue
+    # print("new:",phones)
+    # p,w,n = clean_text_old(text, language)
+    # print("old:",p)
+    return phones, word2ph, text
 
 language_module_map = {"zh": chinese, "ja": japanese, "en": english}
 special = [
@@ -9,7 +226,7 @@ special = [
 ]
 
 
-def clean_text(text, language):
+def clean_text_old(text, language):
     if(language not in language_module_map):
         language="en"
         text=" "


### PR DESCRIPTION
尝试使用阿里KAN-TTS的前端TTSRFD处理文本，需要引入
install ttsfrd==0.2.1 -f https://modelscope.oss-cn-beijing.aliyuncs.com/releases/repo.html
该前端可以处理 %百分号在文本里会导致error不能推理 还有 元/吨 会读成 元吨 而不是元每吨这类问题

兼容性：
1、该前端中文处理可以直接处理中英混合，所以将项目中英混合部分进行了调整，使中英混合部分更加连贯。但该前端无法处理日英混合，会输出像英语又像日语的奇怪英文，继续使用日英切分进行处理。
2、该前端闭源，只支持直接输出处理后的音素，阿里的音素与本项目模型音素存在部分细分不同，直接做了chinese_dict、english_dict、japanese_dict对差异音素进行转换，中文部分几个音不确定转换是否准确，需要更多测试。
3、该前端可以将 ”元/吨“ 处理为 ”元每吨“，”xx/kg"处理为“xx每公斤”，但无法输出处理后的文字，只有音素，导致无法使用get_bert_feature（norm_text和word2ph对应不上），此处直接先像英语日语一样处理。

其他：
LangSegment.getTexts需要标点符号加持才能分割中日，类似“マクドナルド是麦当劳”这样一整句它都会直接输出“ja”“マクドナルド是麦当劳”。只有“マクドナルド，是麦当劳”才能准确分割出中日两段。可能需要做优化。