### PR TITLE
调整Dockerfile所使用模型下载脚本

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ __pycache__
 env
 runtime
 .idea
+output
+logs
+reference
+SoVITS_weights

--- a/Docker/download.py
+++ b/Docker/download.py
@@ -1,7 +1,5 @@
 # Download moda ASR related models
 from modelscope import snapshot_download
-model_dir = snapshot_download('damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch')
-model_dir = snapshot_download('damo/speech_fsmn_vad_zh-cn-16k-common-pytorch')
-model_dir = snapshot_download('damo/punc_ct-transformer_zh-cn-common-vocab272727-pytorch')
-
-
+model_dir = snapshot_download('damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch',revision="v2.0.4")
+model_dir = snapshot_download('damo/speech_fsmn_vad_zh-cn-16k-common-pytorch',revision="v2.0.4")
+model_dir = snapshot_download('damo/punc_ct-transformer_zh-cn-common-vocab272727-pytorch',revision="v2.0.4")


### PR DESCRIPTION
1. 调整Dockerfile所使用模型下载脚本，使得和cmd-asr.py版本保持一致
2. gitignore里增加几个内容输出目录