### PR TITLE
Fix uvr5

### DIFF
--- a/tools/uvr5/mdxnet.py
+++ b/tools/uvr5/mdxnet.py
@@ -239,7 +239,7 @@ class Predictor:
 
 
 class MDXNetDereverb:
-    def __init__(self, chunks, device):
+    def __init__(self, chunks):
         self.onnx = "%s/uvr5_weights/onnx_dereverb_By_FoxJoy"%os.path.dirname(os.path.abspath(__file__))
         self.shifts = 10  # 'Predict with randomised equivariant stabilisation'
         self.mixing = "min_mag"  # ['default','min_mag','max_mag']
@@ -250,7 +250,7 @@ class MDXNetDereverb:
         self.n_fft = 6144
         self.denoise = True
         self.pred = Predictor(self)
-        self.device = device
+        self.device = cpu
 
     def _path_audio_(self, input, vocal_root, others_root, format, is_hp3=False):
         self.pred.prediction(input, vocal_root, others_root, format)

--- a/tools/uvr5/webui.py
+++ b/tools/uvr5/webui.py
@@ -33,9 +33,8 @@ def uvr(model_name, inp_root, save_root_vocal, paths, save_root_ins, agg, format
         save_root_ins = (
             save_root_ins.strip(" ").strip('"').strip("\n").strip('"').strip(" ")
         )
+        is_hp3 = "HP3" in model_name
         if model_name == "onnx_dereverb_By_FoxJoy":
-            from MDXNet import MDXNetDereverb
-
             pre_fun = MDXNetDereverb(15)
         else:
             func = AudioPre if "DeEcho" not in model_name else AudioPreDeEcho
@@ -62,7 +61,7 @@ def uvr(model_name, inp_root, save_root_vocal, paths, save_root_ins, agg, format
                 ):
                     need_reformat = 0
                     pre_fun._path_audio_(
-                        inp_path, save_root_ins, save_root_vocal, format0
+                        inp_path, save_root_ins, save_root_vocal, format0,is_hp3
                     )
                     done = 1
             except:
@@ -81,7 +80,7 @@ def uvr(model_name, inp_root, save_root_vocal, paths, save_root_ins, agg, format
             try:
                 if done == 0:
                     pre_fun._path_audio_(
-                        inp_path, save_root_ins, save_root_vocal, format0
+                        inp_path, save_root_ins, save_root_vocal, format0,is_hp3
                     )
                 infos.append("%s->Success" % (os.path.basename(inp_path)))
                 yield "\n".join(infos)


### PR DESCRIPTION
webui.py:
1、"from MDXNet import MDXNetDereverb"  MDXNet名称不对，开头已从mdxnet引入
2、重建is_hp3，判断模型是否为hp3并作为参数传入pre_fun._path_audio_，用于处理HP3输出问题

mdxnet.py:
1、"def __init__(self, chunks, device)"，因代码默认用cpu，且webui中无传入device，故去除
2、"self.device = device"，同上，改为cpu