### PR TITLE
修复多项目情况下SOVITS训练报错问题-fix default dir miss assertion error

### DIFF
--- a/GPT_SoVITS/module/data_utils.py
+++ b/GPT_SoVITS/module/data_utils.py
@@ -29,9 +29,15 @@ class TextAudioSpeakerLoader(torch.utils.data.Dataset):
 
     def __init__(self, hparams, val=False):
         exp_dir = hparams.exp_dir
+        if not os.path.exists("%s/2-name2text.txt" % exp_dir):
+            exp_dir = "logs/xxx"
+
         self.path2 = "%s/2-name2text.txt" % exp_dir
         self.path4 = "%s/4-cnhubert" % exp_dir
         self.path5 = "%s/5-wav32k" % exp_dir
+
+        f"""-loading self.path2: {self.path2} correctly-"""
+
         assert os.path.exists(self.path2)
         assert os.path.exists(self.path4)
         assert os.path.exists(self.path5)

--- a/GPT_SoVITS/module/data_utils.py
+++ b/GPT_SoVITS/module/data_utils.py
@@ -3,6 +3,8 @@ import logging
 import os
 import random
 import traceback
+from datetime import datetime
+
 import numpy as np
 import torch
 import torch.utils.data
@@ -19,6 +21,7 @@ from scipy.io import wavfile
 from io import BytesIO
 from my_utils import load_audio
 
+
 # ZeroDivisionError fixed by Tybost (https://github.com/RVC-Boss/GPT-SoVITS/issues/79)
 class TextAudioSpeakerLoader(torch.utils.data.Dataset):
     """
@@ -28,13 +31,15 @@ class TextAudioSpeakerLoader(torch.utils.data.Dataset):
     """
 
     def __init__(self, hparams, val=False):
-        exp_dir = hparams.exp_dir
-        if not os.path.exists("%s/2-name2text.txt" % exp_dir):
-            exp_dir = "logs/xxx"
+        self.exp_dir = hparams.exp_dir
 
-        self.path2 = "%s/2-name2text.txt" % exp_dir
-        self.path4 = "%s/4-cnhubert" % exp_dir
-        self.path5 = "%s/5-wav32k" % exp_dir
+        if not os.path.exists("%s/2-name2text.txt" % self.exp_dir): # 如果文件夹为空，寻址最新创建项目
+            parent_dir = "/".join(os.getcwd().split("/")[:-1])
+            self.find_newest_folder(parent_dir)
+
+        self.path2 = "%s/2-name2text.txt" % self.exp_dir
+        self.path4 = "%s/4-cnhubert" % self.exp_dir
+        self.path5 = "%s/5-wav32k" % self.exp_dir
 
         f"""-loading self.path2: {self.path2} correctly-"""
 
@@ -110,6 +115,20 @@ class TextAudioSpeakerLoader(torch.utils.data.Dataset):
         self.audiopaths_sid_text = audiopaths_sid_text_new
         self.lengths = lengths
 
+    def find_newest_folder(self, directory):
+        if os.path.exists(directory):
+            try:
+                for root, dirs, files in os.walk(directory):
+                    # 获取当前目录下所有子文件夹的修改时间
+                    folder_times = [datetime.fromtimestamp(os.path.getmtime(root + '/' + d)) for d in dirs]
+
+                    if len(folder_times) > 0:
+                        # 根据修改时间选择最新的子文件夹
+                        self.exp_dir = max(zip(folder_times, dirs), key=lambda x: x[0])[-1]
+            except:
+                f"""locating newest folder fail in {directory}"""
+                return
+
     def get_audio_text_speaker_pair(self, audiopath_sid_text):
         audiopath, phoneme_ids = audiopath_sid_text
         text = torch.FloatTensor(phoneme_ids)
@@ -136,7 +155,7 @@ class TextAudioSpeakerLoader(torch.utils.data.Dataset):
         audio_norm = audio
         audio_norm = audio_norm.unsqueeze(0)
         spec = spectrogram_torch(audio_norm, self.filter_length, self.sampling_rate, self.hop_length, self.win_length,
-                                  center=False)
+                                 center=False)
         spec = torch.squeeze(spec, 0)
         return spec, audio_norm
 
@@ -153,7 +172,7 @@ class TextAudioSpeakerLoader(torch.utils.data.Dataset):
 
     def random_slice(self, ssl, wav, mel):
         assert abs(ssl.shape[-1] - wav.shape[-1] // self.hop_length) < 3, (
-        "first", ssl.shape, wav.shape)
+            "first", ssl.shape, wav.shape)
 
         len_mel = mel.shape[1]
         if self.val:
@@ -174,7 +193,7 @@ class TextAudioSpeakerLoader(torch.utils.data.Dataset):
             mel = mel[:, :sep_point]
 
         assert abs(ssl.shape[-1] - wav2.shape[-1] // self.hop_length) < 3, (
-        ssl.shape, wav.shape, wav2.shape, mel.shape, sep_point, self.hop_length, sep_point * self.hop_length, dir)
+            ssl.shape, wav.shape, wav2.shape, mel.shape, sep_point, self.hop_length, sep_point * self.hop_length, dir)
         return reference_mel, ssl, wav2, mel
 
 


### PR DESCRIPTION
问题描述：
`self.path2:  logs/self-test/2-name2text.txt
self.path4:  logs/self-test/4-cnhubert
self.path5:  logs/self-test/5-wav32k
Traceback (most recent call last):
  File "E:\软件\GPT-SoVITS-beta\GPT_SoVITS\s2_train.py", line 600, in <module>
    main()
  File "E:\软件\GPT-SoVITS-beta\GPT_SoVITS\s2_train.py", line 56, in main
    mp.spawn(
  File "E:\软件\GPT-SoVITS-beta\runtime\lib\site-packages\torch\multiprocessing\spawn.py", line 239, in spawn
    return start_processes(fn, args, nprocs, join, daemon, start_method='spawn')
  File "E:\软件\GPT-SoVITS-beta\runtime\lib\site-packages\torch\multiprocessing\spawn.py", line 197, in start_processes
    while not context.join():
  File "E:\软件\GPT-SoVITS-beta\runtime\lib\site-packages\torch\multiprocessing\spawn.py", line 160, in join
    raise ProcessRaisedException(msg, error_index, failed_process.pid)
torch.multiprocessing.spawn.ProcessRaisedException:

-- Process 0 terminated with the following error:
Traceback (most recent call last):
  File "E:\软件\GPT-SoVITS-beta\runtime\lib\site-packages\torch\multiprocessing\spawn.py", line 69, in _wrap
    fn(i, *args)
  File "E:\软件\GPT-SoVITS-beta\GPT_SoVITS\s2_train.py", line 85, in run
    train_dataset = TextAudioSpeakerLoader(hps.data)  ########
  File "E:\软件\GPT-SoVITS-beta\GPT_SoVITS\module\data_utils.py", line 38, in __init__
    assert os.path.exists(self.path2)
AssertionError`

问题定位：
默认设置跑GPT-SOVITS训练时会报AssertionError，原因如下：
- 同时创建了新命名项目（self-test）和默认项目xxx，导致hparams目录参数混淆（2-name2text.txt、4、5都保存在xxx下）
- 如果同时创建大于2个项目，比如self-text1、self-test2、xxx，会出现寻址错误（self-text1的项目下实际为空）

解决方案：
加一层简单判断，如果该文件不存在，尝试寻找父级目录下最新创建的文件夹，也即上一层数据标注处理后新生成的文件所在位置。此时可以让路径下的name2text.txt/cnhuber/wav32k 正确导入，从而解决报错问题。