### PR TITLE
适配更高版本的 librosa

### DIFF
--- a/tools/uvr5/lib/lib_v5/spec_utils.py
+++ b/tools/uvr5/lib/lib_v5/spec_utils.py
@@ -43,8 +43,8 @@ def wave_to_spectrogram(
         wave_left = np.asfortranarray(wave[0])
         wave_right = np.asfortranarray(wave[1])
 
-    spec_left = librosa.stft(wave_left, n_fft, hop_length=hop_length)
-    spec_right = librosa.stft(wave_right, n_fft, hop_length=hop_length)
+    spec_left  = librosa.stft(wave_left,  n_fft=n_fft, hop_length=hop_length)
+    spec_right = librosa.stft(wave_right, n_fft=n_fft, hop_length=hop_length)
 
     spec = np.asfortranarray([spec_left, spec_right])
 
@@ -78,7 +78,7 @@ def wave_to_spectrogram_mt(
         kwargs={"y": wave_left, "n_fft": n_fft, "hop_length": hop_length},
     )
     thread.start()
-    spec_right = librosa.stft(wave_right, n_fft, hop_length=hop_length)
+    spec_right = librosa.stft(wave_right, n_fft=n_fft, hop_length=hop_length)
     thread.join()
 
     spec = np.asfortranarray([spec_left, spec_right])
@@ -230,27 +230,31 @@ def cache_or_load(mix_path, inst_path, mp):
 
             if d == len(mp.param["band"]):  # high-end band
                 X_wave[d], _ = librosa.load(
-                    mix_path, bp["sr"], False, dtype=np.float32, res_type=bp["res_type"]
+                    mix_path, 
+                    sr       = bp["sr"],
+                    mono     = False,
+                    dtype    = np.float32,
+                    res_type = bp["res_type"]
                 )
                 y_wave[d], _ = librosa.load(
                     inst_path,
-                    bp["sr"],
-                    False,
-                    dtype=np.float32,
-                    res_type=bp["res_type"],
+                    sr       = bp["sr"],
+                    mono     = False,
+                    dtype    = np.float32,
+                    res_type = bp["res_type"],
                 )
             else:  # lower bands
                 X_wave[d] = librosa.resample(
                     X_wave[d + 1],
-                    mp.param["band"][d + 1]["sr"],
-                    bp["sr"],
-                    res_type=bp["res_type"],
+                    orig_sr   = mp.param["band"][d + 1]["sr"],
+                    target_sr = bp["sr"],
+                    res_type  = bp["res_type"],
                 )
                 y_wave[d] = librosa.resample(
                     y_wave[d + 1],
-                    mp.param["band"][d + 1]["sr"],
-                    bp["sr"],
-                    res_type=bp["res_type"],
+                    orig_sr   = mp.param["band"][d + 1]["sr"],
+                    target_sr = bp["sr"],
+                    res_type  = bp["res_type"],
                 )
 
             X_wave[d], y_wave[d] = align_wave_head_and_tail(X_wave[d], y_wave[d])
@@ -401,9 +405,9 @@ def cmb_spectrogram_to_wave(spec_m, mp, extra_bins_h=None, extra_bins=None):
                         mp.param["mid_side_b2"],
                         mp.param["reverse"],
                     ),
-                    bp["sr"],
-                    sr,
-                    res_type="sinc_fastest",
+                    orig_sr   = bp["sr"],
+                    target_sr = sr,
+                    res_type  = "sinc_fastest",
                 )
             else:  # mid
                 spec_s = fft_hp_filter(spec_s, bp["hpf_start"], bp["hpf_stop"] - 1)
@@ -418,8 +422,8 @@ def cmb_spectrogram_to_wave(spec_m, mp, extra_bins_h=None, extra_bins=None):
                         mp.param["reverse"],
                     ),
                 )
-                # wave = librosa.core.resample(wave2, bp['sr'], sr, res_type="sinc_fastest")
-                wave = librosa.core.resample(wave2, bp["sr"], sr, res_type="scipy")
+                # wave = librosa.core.resample(wave2, orig_sr=bp['sr'], target_sr=sr, res_type="sinc_fastest")
+                wave = librosa.core.resample(wave2, orig_sr=bp["sr"], target_sr=sr, res_type="scipy")
 
     return wave.T
 
@@ -506,8 +510,8 @@ def ensembling(a, specs):
 def stft(wave, nfft, hl):
     wave_left = np.asfortranarray(wave[0])
     wave_right = np.asfortranarray(wave[1])
-    spec_left = librosa.stft(wave_left, nfft, hop_length=hl)
-    spec_right = librosa.stft(wave_right, nfft, hop_length=hl)
+    spec_left = librosa.stft(wave_left, n_fft=nfft, hop_length=hl)
+    spec_right = librosa.stft(wave_right, n_fft=nfft, hop_length=hl)
     spec = np.asfortranarray([spec_left, spec_right])
 
     return spec
@@ -569,10 +573,10 @@ if __name__ == "__main__":
             if d == len(mp.param["band"]):  # high-end band
                 wave[d], _ = librosa.load(
                     args.input[i],
-                    bp["sr"],
-                    False,
-                    dtype=np.float32,
-                    res_type=bp["res_type"],
+                    sr       = bp["sr"],
+                    mono     = False,
+                    dtype    = np.float32,
+                    res_type = bp["res_type"],
                 )
 
                 if len(wave[d].shape) == 1:  # mono to stereo
@@ -580,9 +584,9 @@ if __name__ == "__main__":
             else:  # lower bands
                 wave[d] = librosa.resample(
                     wave[d + 1],
-                    mp.param["band"][d + 1]["sr"],
-                    bp["sr"],
-                    res_type=bp["res_type"],
+                    orig_sr   = mp.param["band"][d + 1]["sr"],
+                    target_sr = bp["sr"],
+                    res_type  = bp["res_type"],
                 )
 
             spec[d] = wave_to_spectrogram(

--- a/tools/uvr5/vr.py
+++ b/tools/uvr5/vr.py
@@ -61,19 +61,19 @@ class AudioPre:
                     _,
                 ) = librosa.core.load(  # 理论上librosa读取可能对某些音频有bug，应该上ffmpeg读取，但是太麻烦了弃坑
                     music_file,
-                    bp["sr"],
-                    False,
-                    dtype=np.float32,
-                    res_type=bp["res_type"],
+                    sr       = bp["sr"],
+                    mono     = False,
+                    dtype    = np.float32,
+                    res_type = bp["res_type"],
                 )
                 if X_wave[d].ndim == 1:
                     X_wave[d] = np.asfortranarray([X_wave[d], X_wave[d]])
             else:  # lower bands
                 X_wave[d] = librosa.core.resample(
                     X_wave[d + 1],
-                    self.mp.param["band"][d + 1]["sr"],
-                    bp["sr"],
-                    res_type=bp["res_type"],
+                    orig_sr   = self.mp.param["band"][d + 1]["sr"],
+                    target_sr = bp["sr"],
+                    res_type  = bp["res_type"],
                 )
             # Stft of wave source
             X_spec_s[d] = spec_utils.wave_to_spectrogram_mt(
@@ -245,19 +245,19 @@ class AudioPreDeEcho:
                     _,
                 ) = librosa.core.load(  # 理论上librosa读取可能对某些音频有bug，应该上ffmpeg读取，但是太麻烦了弃坑
                     music_file,
-                    bp["sr"],
-                    False,
-                    dtype=np.float32,
-                    res_type=bp["res_type"],
+                    sr       = bp["sr"],
+                    mono     = False,
+                    dtype    = np.float32,
+                    res_type = bp["res_type"],
                 )
                 if X_wave[d].ndim == 1:
                     X_wave[d] = np.asfortranarray([X_wave[d], X_wave[d]])
             else:  # lower bands
                 X_wave[d] = librosa.core.resample(
                     X_wave[d + 1],
-                    self.mp.param["band"][d + 1]["sr"],
-                    bp["sr"],
-                    res_type=bp["res_type"],
+                    orig_sr   = self.mp.param["band"][d + 1]["sr"],
+                    target_sr = bp["sr"],
+                    res_type  = bp["res_type"],
                 )
             # Stft of wave source
             X_spec_s[d] = spec_utils.wave_to_spectrogram_mt(


### PR DESCRIPTION
Librosa 更新到 0.10.0+ 时，位置参数需要修改为关键字参数，且不影响 Libsora=0.9.2 时运行。
否则会出现
```
TypeError: load() takes 1 positional argument but 3 positional arguments (and 2 keyword-only arguments) were given
```
