### PR TITLE
feat: incase too much \n

### DIFF
--- a/GPT_SoVITS/inference_webui.py
+++ b/GPT_SoVITS/inference_webui.py
@@ -390,7 +390,8 @@ def get_tts_wav(ref_wav_path, prompt_text, prompt_language, text, text_language,
         text = cut4(text)
     elif (how_to_cut == i18n("按标点符号切")):
         text = cut5(text)
-    text = text.replace("\n\n", "\n").replace("\n\n", "\n").replace("\n\n", "\n")
+    while "\n\n" in text:
+        text = text.replace("\n\n", "\n")
     print(i18n("实际输入的目标文本(切句后):"), text)
     texts = text.split("\n")
     audio_opt = []


### PR DESCRIPTION
test case:

```
def replace1(text):
    return text.replace("\n\n", "\n").replace("\n\n", "\n").replace("\n\n", "\n")

def replace2(text):
    while "\n\n" in text:
        text = text.replace("\n\n", "\n")
    return text

text = "123456789\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n987654321"
print(replace1(text))
print("--------------")
print(replace2(text))
```