### PR TITLE
feat: in case ignore too short text

### DIFF
--- a/GPT_SoVITS/inference_webui.py
+++ b/GPT_SoVITS/inference_webui.py
@@ -342,6 +342,20 @@ def get_bert_final(phones, word2ph, text,language,device):
         bert = torch.zeros((1024, len(phones))).to(device)
     return bert
 
+def merge_short_text_in_array(texts, threshold):
+    if (len(texts)) < 2:
+        return texts
+    result = []
+    text = ""
+    for ele in texts:
+        text += ele
+        if len(text) >= threshold:
+            result.append(text)
+            text = ""
+    if (len(text) > 0):
+        result[len(result)] += text
+    return result
+
 def get_tts_wav(ref_wav_path, prompt_text, prompt_language, text, text_language, how_to_cut=i18n("不切")):
     t0 = ttime()
     prompt_language = dict_language[prompt_language]
@@ -393,6 +407,7 @@ def get_tts_wav(ref_wav_path, prompt_text, prompt_language, text, text_language,
     text = text.replace("\n\n", "\n").replace("\n\n", "\n").replace("\n\n", "\n")
     print(i18n("实际输入的目标文本(切句后):"), text)
     texts = text.split("\n")
+    texts = merge_short_text_in_array(texts, 5)
     audio_opt = []
     bert1=get_bert_final(phones1, word2ph1, norm_text1,prompt_language,device).to(dtype)
 


### PR DESCRIPTION
# 描述：
有时，字太少时，合成会被忽略掉
如图，输出结果中，
"近日"和"对此" 会被忽略（在输出结果中就没有对应的音频）

![image](https://github.com/RVC-Boss/GPT-SoVITS/assets/14890206/94caffa3-9877-4c37-a5eb-424f57350c6e)


### 其他
get_tts_wav函数入参：
```
ref_wav_path = 上传结果
prompt_text = 上传结果
prompt_language = "Chinese"
text = "近日，茶饮品牌茶颜悦色工商变更，企业类型变更并引入新股东，市场猜测是为赴港上市做准备。对此，茶颜悦色方面对此回应称，暂时没有明确的上市计划。对于茶颜悦色的这系列变更，一家关注消费行业的投资机构分析师表示，股权变更可能是在为上市做准备，但并不代表最后能上市，是上市的必要不充分条件。但是股权变更也可能是其他情况，比如架构重组，开展新业务，引入新股东。（红星新闻）。"
text_language = "Chinese"
how_to_cut = "按标点符号切"
```

merge_short_text_in_array 函数测试
```
def merge_short_text_in_array(texts, threshold):
    if (len(texts)) < 2:
        return texts
    result = []
    text = ""
    for ele in texts:
        text += ele
        if len(text) >= threshold:
            result.append(text)
            text = ""
    if (len(text) > 0):
        result[len(result)] += text
    return result

def test_merge_short_text_in_array():
    texts = []
    text = ""
    for i in range(1, 10):
        text = text + str(i)
        texts.append(text)
    print("before:")
    print(texts)
    texts = merge_short_text_in_array(texts, 6)
    print("after:")
    print(texts)

test_merge_short_text_in_array()
```