### PR TITLE
修改显卡设备编号循环读取的bug

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -377,10 +377,14 @@ def open1a(inp_text,inp_wav_dir,exp_name,gpu_numbers,bert_pretrained_dir):
             p.wait()
         opt = []
         for i_part in range(all_parts):
-            txt_path = "%s/2-name2text-%s.txt" % (opt_dir, i_part)
-            with open(txt_path, "r", encoding="utf8") as f:
-                opt += f.read().strip("\n").split("\n")
-            os.remove(txt_path)
+            try:
+                txt_path = "%s/2-name2text-%s.txt" % (opt_dir, i_part)
+                with open(txt_path, "r", encoding="utf8") as f:
+                    opt += f.read().strip("\n").split("\n")
+                os.remove(txt_path)
+            except Exception as e:
+                print(str(e))
+                pass
         path_text = "%s/2-name2text.txt" % opt_dir
         with open(path_text, "w", encoding="utf8") as f:
             f.write("\n".join(opt) + "\n")


### PR DESCRIPTION
修改显卡设备编号循环读取的bug，导致首次循环报错

<img width="1001" alt="1707374072970" src="https://github.com/RVC-Boss/GPT-SoVITS/assets/1288038/d809b94e-b668-4382-8153-4a29ddc992a6">
