### PR TITLE
automatically disable fp16 in inference_webui.py (and code reuse)

### DIFF
--- a/GPT_SoVITS/inference_webui.py
+++ b/GPT_SoVITS/inference_webui.py
@@ -44,11 +44,9 @@ bert_path = os.environ.get(
 )
 infer_ttswebui = os.environ.get("infer_ttswebui", 9872)
 infer_ttswebui = int(infer_ttswebui)
-is_share = os.environ.get("is_share", "False")
-is_share = eval(is_share)
 if "_CUDA_VISIBLE_DEVICES" in os.environ:
     os.environ["CUDA_VISIBLE_DEVICES"] = os.environ["_CUDA_VISIBLE_DEVICES"]
-is_half = eval(os.environ.get("is_half", "True"))
+from config import is_half,is_share
 import gradio as gr
 from transformers import AutoModelForMaskedLM, AutoTokenizer
 import numpy as np


### PR DESCRIPTION
Enhancement:
Reuse environment var parsing logic in config.py, to reduce code duplication and enable automatic fp16 device detection when no env var override exists

I mean why not, webui.py is done this way
https://github.com/RVC-Boss/GPT-SoVITS/blob/f6c9803909dbca7d61062367182c78ceb91531a0/webui.py#L51

