### PR TITLE
修正g2p_en的英文字母发音问题

### DIFF
--- a/GPT_SoVITS/text/english.py
+++ b/GPT_SoVITS/text/english.py
@@ -169,9 +169,9 @@ def read_dict_new():
                 line = line.strip()
                 word_split = line.split(" ")
                 word = word_split[0]
-                if word not in g2p_dict:
-                    g2p_dict[word] = []
-                    g2p_dict[word].append(word_split[1:])
+                #if word not in g2p_dict:
+                g2p_dict[word] = []
+                g2p_dict[word].append(word_split[1:])
 
             line_index = line_index + 1
             line = f.readline()


### PR DESCRIPTION
热词应该是覆盖逻辑，因为原版字典里如果key存在的话，那么用户定义的热词纠正发音就不会生效，举个例子，原版字典里AI这个key的发音是AH0，但实际上应该是EY1 - AY1，但如果用户在热词字典了定义了新的读音EY1 - AY1，是不生效的，以为原版字典里已经有了AI的key，所以理论上热词字典新定义的key应该是覆盖原字典key的逻辑