### PR TITLE
Fix Issue with Share Link Generation in colab_webui.ipynb

### DIFF
--- a/colab_webui.ipynb
+++ b/colab_webui.ipynb
@@ -82,7 +82,7 @@
       "source": [
         "# @title launch WebUI 启动WebUI\n",
         "!/usr/local/bin/pip install ipykernel\n",
-        "!sed -i '9s/False/True/' /content/GPT-SoVITS/config.py\n",
+        "!sed -i 's/os.environ.get("is_share","False")/os.environ.get("is_share","True")/g' /content/GPT-SoVITS/config.py\n",
         "%cd /content/GPT-SoVITS/\n",
         "!/usr/local/bin/python  webui.py"
       ],


### PR DESCRIPTION
Modified the way we retrieve the "is_share" environment variable.