### PR TITLE
Change the inference device on Mac

### DIFF
--- a/GPT_SoVITS/inference_webui.py
+++ b/GPT_SoVITS/inference_webui.py
@@ -72,8 +72,6 @@ os.environ['PYTORCH_ENABLE_MPS_FALLBACK'] = '1'  # 确保直接启动推理UI时
 
 if torch.cuda.is_available():
     device = "cuda"
-elif torch.backends.mps.is_available():
-    device = "cpu"
 else:
     device = "cpu"
 

--- a/GPT_SoVITS/inference_webui.py
+++ b/GPT_SoVITS/inference_webui.py
@@ -73,7 +73,7 @@ os.environ['PYTORCH_ENABLE_MPS_FALLBACK'] = '1'  # 确保直接启动推理UI时
 if torch.cuda.is_available():
     device = "cuda"
 elif torch.backends.mps.is_available():
-    device = "mps"
+    device = "cpu"
 else:
     device = "cpu"
 

--- a/config.py
+++ b/config.py
@@ -20,7 +20,7 @@ python_exec = sys.executable or "python"
 if torch.cuda.is_available():
     infer_device = "cuda"
 elif torch.backends.mps.is_available():
-    infer_device = "mps"
+    infer_device = "cpu"
 else:
     infer_device = "cpu"
 

--- a/config.py
+++ b/config.py
@@ -19,8 +19,6 @@ exp_root = "logs"
 python_exec = sys.executable or "python"
 if torch.cuda.is_available():
     infer_device = "cuda"
-elif torch.backends.mps.is_available():
-    infer_device = "cpu"
 else:
     infer_device = "cpu"
 


### PR DESCRIPTION
Using CPU inference on Mac to accelerate inference speed and reduce memory leak