### PR TITLE
在requestments新增了一个包einops

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 numpy
 scipy
 tensorboard
-einops
 librosa==0.9.2
 numba==0.56.4
 pytorch-lightning
@@ -26,3 +25,4 @@ jieba_fast
 jieba
 LangSegment>=0.2.0
 Faster_Whisper
+einops

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 numpy
 scipy
 tensorboard
+einops
 librosa==0.9.2
 numba==0.56.4
 pytorch-lightning


### PR DESCRIPTION
ubuntu启动api.py时候没有这个包会报错
今天从github拉源码部署自己4090机器时候发现，包下完了，启动api.py的时候会出现。

<img width="720" alt="c135fe8fbf8feee524b43b57467340f" src="https://github.com/RVC-Boss/GPT-SoVITS/assets/34533090/b9e2f887-e83b-4acc-a389-eb602a9a60fa">

然后我用conda把这个包pip install就成功了

所以我就把这个包放到了requirements里。