### PR TITLE
解决api调用时文本有连续换行导致的报错问题

### DIFF
--- a/api.py
+++ b/api.py
@@ -378,7 +378,8 @@ def get_tts_wav(ref_wav_path, prompt_text, prompt_language, text, text_language)
     text_language = dict_language[text_language]
     phones1, word2ph1, norm_text1 = clean_text(prompt_text, prompt_language)
     phones1 = cleaned_text_to_sequence(phones1)
-    texts = text.split("\n")
+    _ = text.split("\n")
+    texts = [t for t in _ if t != '']
     audio_opt = []
 
     for text in texts:


### PR DESCRIPTION
当 API 接收到的 text 输入参数包含两个或两个以上的连续换行符 '\n' 时，使用 split('\n') 方法拆分字符串会在结果列表中产生空字符串元素 ('')。然后程序在调用torch.cat()时就会报出 RuntimeError。

错误示例：

python
texts = "这是第一行\n\n这是第三行"
texts_split = texts.split('\n')
# texts_split 结果是 ['这是第一行', '', '这是第三行']
# 其中的 '' 会导致后续的 torch.cat() 操作失败
错误信息：
...
RuntimeError: torch.cat(): expected a non-empty list of Tensors