### PR TITLE
remove UserWarning: stft with return_complex=False is deprecated. 

### DIFF
--- a/GPT_SoVITS/module/mel_processing.py
+++ b/GPT_SoVITS/module/mel_processing.py
@@ -133,7 +133,6 @@ def mel_spectrogram_torch(
     )
     y = y.squeeze(1)
 
-
     spec = torch.stft(
         y,
         n_fft,

--- a/GPT_SoVITS/module/mel_processing.py
+++ b/GPT_SoVITS/module/mel_processing.py
@@ -78,8 +78,9 @@ def spectrogram_torch(y, n_fft, sampling_rate, hop_size, win_size, center=False)
         pad_mode="reflect",
         normalized=False,
         onesided=True,
-        return_complex=False,
+        return_complex=True
     )
+    spec = torch.view_as_real(spec)
 
     spec = torch.sqrt(spec.pow(2).sum(-1) + 1e-6)
     return spec
@@ -132,6 +133,7 @@ def mel_spectrogram_torch(
     )
     y = y.squeeze(1)
 
+
     spec = torch.stft(
         y,
         n_fft,
@@ -142,8 +144,9 @@ def mel_spectrogram_torch(
         pad_mode="reflect",
         normalized=False,
         onesided=True,
-        return_complex=False,
+        return_complex=True,
     )
+    spec = torch.view_as_real(spec)
 
     spec = torch.sqrt(spec.pow(2).sum(-1) + 1e-6)
 


### PR DESCRIPTION
#600 #681 去掉训练 SoVITS 时出现的一个 Warning 不影响其他部分:
```
~\envs\cuda12\lib\site-packages\torch\functional.py:650: 
UserWarning: stft with return_complex=False is deprecated. 
In a future pytorch release, stft will return complex tensors for all inputs, 
and return_complex=False will raise an error.
Note: you can still call torch.view_as_real on the complex output to recover the old return format. 
(Triggered internally at C:\actions-runner\_work\pytorch\pytorch\builder\windows
\pytorch\aten\src\ATen\native\SpectralOps.cpp:868.)  
```

- [x] 通过 `Tensor1.equal(Tensor2)` 验证修改前后张量 `spec` 结果一致