### PR TITLE
bugfix for import local tools module failed

### DIFF
--- a/tools/uvr5/uvr5_weights/.gitignore
+++ b/tools/uvr5/uvr5_weights/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/webui.py
+++ b/webui.py
@@ -1,6 +1,8 @@
 import os,shutil,sys,pdb,re
 now_dir = os.getcwd()
-sys.path.append(now_dir)
+print(now_dir)
+sys.path.insert(0, now_dir)
+print(sys.path)
 import json,yaml,warnings,torch
 import platform
 import psutil

--- a/webui.py
+++ b/webui.py
@@ -1,8 +1,6 @@
 import os,shutil,sys,pdb,re
 now_dir = os.getcwd()
-print(now_dir)
 sys.path.insert(0, now_dir)
-print(sys.path)
 import json,yaml,warnings,torch
 import platform
 import psutil


### PR DESCRIPTION

I think if you want to import local module (e.g. `from toos import my_utils`) by modifying `sys.path`, it's better to replace `sys.path.apped()` with `sys.path.insert()`. Because some `tools` has been exists in `sys.path`.

```shell
Traceback (most recent call last):
  File "/workspace/GPT-SoVITS/webui.py", line 44, in <module>
    from tools import my_utils
ImportError: cannot import name 'my_utils' from 'tools' (/opt/conda/lib/python3.10/site-packages/tools/__init__.py)
```