### PR TITLE
修复 Fast Inference 分支的多语言 bug

### DIFF
--- a/GPT_SoVITS/TTS_infer_pack/TTS.py
+++ b/GPT_SoVITS/TTS_infer_pack/TTS.py
@@ -97,7 +97,6 @@ class TTS_Config:
             configs = yaml.load(f, Loader=yaml.FullLoader)
     
         return configs
-    
 
     def save_configs(self, configs_path:str=None)->None:
         configs={
@@ -110,22 +109,27 @@ class TTS_Config:
                 "bert_base_path": "GPT_SoVITS/pretrained_models/chinese-roberta-wwm-ext-large",
                 "flash_attn_enabled": True
             },
-            "custom": {
-                "device": str(self.device),
-                "is_half": self.is_half,
-                "t2s_weights_path": self.t2s_weights_path,
-                "vits_weights_path": self.vits_weights_path,
-                "bert_base_path": self.bert_base_path,
-                "cnhuhbert_base_path": self.cnhuhbert_base_path,
-                "flash_attn_enabled": self.flash_attn_enabled
-            }
+            "custom": self.update_configs()
         }
         if configs_path is None:
             configs_path = self.configs_path
         with open(configs_path, 'w') as f:
             yaml.dump(configs, f)
+
+    def update_configs(self):
+        config = {
+            "device"             : str(self.device),
+            "is_half"            : self.is_half,
+            "t2s_weights_path"   : self.t2s_weights_path,
+            "vits_weights_path"  : self.vits_weights_path,
+            "bert_base_path"     : self.bert_base_path,
+            "cnhuhbert_base_path": self.cnhuhbert_base_path,
+            "flash_attn_enabled" : self.flash_attn_enabled
+        }
+        return config
             
     def __str__(self):
+        self.configs = self.update_configs()
         string = "TTS Config".center(100, '-') + '\n'
         for k, v in self.configs.items():
             string += f"{str(k).ljust(20)}: {str(v)}\n"

--- a/GPT_SoVITS/TTS_infer_pack/TTS.py
+++ b/GPT_SoVITS/TTS_infer_pack/TTS.py
@@ -125,17 +125,11 @@ class TTS_Config:
         with open(configs_path, 'w') as f:
             yaml.dump(configs, f)
             
-            
     def __str__(self):
-        string = "----------------TTS Config--------------\n"
-        string += "device: {}\n".format(self.device)
-        string += "is_half: {}\n".format(self.is_half)
-        string += "bert_base_path: {}\n".format(self.bert_base_path)
-        string += "t2s_weights_path: {}\n".format(self.t2s_weights_path)
-        string += "vits_weights_path: {}\n".format(self.vits_weights_path)
-        string += "cnhuhbert_base_path: {}\n".format(self.cnhuhbert_base_path)
-        string += "flash_attn_enabled: {}\n".format(self.flash_attn_enabled)
-        string += "----------------------------------------\n"
+        string = "TTS Config".center(100, '-') + '\n'
+        for k, v in self.configs.items():
+            string += f"{str(k).ljust(20)}: {str(v)}\n"
+        string += "-" * 100 + '\n'
         return string
 
 

--- a/GPT_SoVITS/TTS_infer_pack/TextPreprocessor.py
+++ b/GPT_SoVITS/TTS_infer_pack/TextPreprocessor.py
@@ -152,8 +152,7 @@ class TextPreprocessor:
         bert_feature = torch.cat(bert_feature_list, dim=1)
         # phones = sum(phones_list, [])
         norm_text = ''.join(norm_text_list)
-
-        return phones, bert_feature, norm_text
+        return phones_list, bert_feature, norm_text
 
 
     def get_bert_feature(self, text:str, word2ph:list)->torch.Tensor:


### PR DESCRIPTION
## 1. 选择中英混合/多语种模式时, 出现如下错误:
测试语句: `本软件以MIT协议开源, 作者不对软件具备任何控制力, 使用软件者、传播软件导出的声音者自负全责.`
选择语言: `中英混合`/`多语种混合`
报错截图:
![fig1](https://github.com/RVC-Boss/GPT-SoVITS/assets/36986837/dc5c5eca-802f-4eec-ba22-2cdbc1855bb5)

问题定位:
`TTS_infer_pack/TextPreprocessor.py` 中 `TextPreprocessor.extract_bert_feature()` 函数应该输出 `phones_list` 而不是 `phone`.
单语言时两者相同, 因此不出错; 多语言会产生多分段, 输出 `phone` 会只取最后一段, 和后续相关变量长度不对应.

## 2. 修改 TTS 配置打印显示 (强迫症.jpg):
- 将 `TTS_infer_pack/TTS.py/TTS_Config.__str__()` 打印固定配置项修改为遍历打印, 方便新增配置项.
- 打印结果进行对齐.

由
```
----------------TTS Config--------------
device: cuda
is_half: True
bert_base_path: GPT_SoVITS/pretrained_models/chinese-roberta-wwm-ext-large
t2s_weights_path: GPT_SoVITS/pretrained_models/s1bert25hz-2kh-longer-epoch=68e-step=50232.ckpt
vits_weights_path: GPT_SoVITS/pretrained_models/s2G488k.pth
cnhuhbert_base_path: GPT_SoVITS/pretrained_models/chinese-hubert-base
flash_attn_enabled: True
----------------------------------------
```
调整为:

```
---------------------------------------------TTS Config---------------------------------------------
bert_base_path      : GPT_SoVITS/pretrained_models/chinese-roberta-wwm-ext-large
cnhuhbert_base_path : GPT_SoVITS/pretrained_models/chinese-hubert-base
device              : cuda
flash_attn_enabled  : True
is_half             : True
t2s_weights_path    : GPT_SoVITS/pretrained_models/s1bert25hz-2kh-longer-epoch=68e-step=50232.ckpt
vits_weights_path   : GPT_SoVITS/pretrained_models/s2G488k.pth
----------------------------------------------------------------------------------------------------
```


