### PR TITLE
【Fast inference 分支】有关于切分句子单句过长会出现问题，并且增加了一种新的切分方法

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,11 @@ reference
 GPT_weights
 SoVITS_weights
 TEMP
+PortableGit
+
+
 ffmpeg.exe
 ffprobe.exe
+*.bat
+PortableGit/
 

--- a/GPT_SoVITS/TTS_infer_pack/text_segmentation_method.py
+++ b/GPT_SoVITS/TTS_infer_pack/text_segmentation_method.py
@@ -1,7 +1,3 @@
-
-
-
-
 import re
 from typing import Callable
 from tools.i18n.i18n import I18nAuto
@@ -24,31 +20,20 @@ def register_method(name):
 
 splits = {"，", "。", "？", "！", ",", ".", "?", "!", "~", ":", "：", "—", "…", }
 
-def split_big_text(text, max_len=510):
-    # 定义全角和半角标点符号
-    punctuation = "".join(splits)
-
-    # 切割文本
-    segments = re.split('([' + punctuation + '])', text)
+# contributed by XTer
+# 简单的按长度切分，不希望出现超长的句子
+def split_big_text(text, max_length=510):
     
-    # 初始化结果列表和当前片段
-    result = []
-    current_segment = ''
-    
-    for segment in segments:
-        # 如果当前片段加上新的片段长度超过max_len，就将当前片段加入结果列表，并重置当前片段
-        if len(current_segment + segment) > max_len:
-            result.append(current_segment)
-            current_segment = segment
-        else:
-            current_segment += segment
-    
-    # 将最后一个片段加入结果列表
-    if current_segment:
-        result.append(current_segment)
-    
-    return result
-
+    opts = []
+    sentences = text.split('\n')
+    for sentence in sentences:
+        while len(sentence) > max_length:
+            part = sentence[:max_length]
+            opts.append(part)
+            sentence = sentence[max_length:]
+        if sentence:
+            opts.append(sentence)
+    return "\n".join(opts)
 
 
 def split(todo_text):
@@ -79,7 +64,7 @@ def cut0(inp):
 # 凑四句一切
 @register_method("cut1")
 def cut1(inp):
-    inp = inp.strip("\n")
+    inp = split_big_text(inp).strip("\n")
     inps = split(inp)
     split_idx = list(range(0, len(inps), 4))
     split_idx[-1] = None
@@ -91,10 +76,11 @@ def cut1(inp):
         opts = [inp]
     return "\n".join(opts)
 
+
 # 凑50字一切
 @register_method("cut2")
-def cut2(inp):
-    inp = inp.strip("\n")
+def cut2(inp, max_length=50):
+    inp = split_big_text(inp).strip("\n")
     inps = split(inp)
     if len(inps) < 2:
         return inp
@@ -104,7 +90,7 @@ def cut2(inp):
     for i in range(len(inps)):
         summ += len(inps[i])
         tmp_str += inps[i]
-        if summ > 50:
+        if summ > max_length:
             summ = 0
             opts.append(tmp_str)
             tmp_str = ""
@@ -116,16 +102,18 @@ def cut2(inp):
         opts = opts[:-1]
     return "\n".join(opts)
 
+
 # 按中文句号。切
 @register_method("cut3")
 def cut3(inp):
-    inp = inp.strip("\n")
+    inp = split_big_text(inp).strip("\n")
     return "\n".join(["%s" % item for item in inp.strip("。").split("。")])
 
-#按英文句号.切
+
+# 按英文句号.切
 @register_method("cut4")
 def cut4(inp):
-    inp = inp.strip("\n")
+    inp = split_big_text(inp).strip("\n")
     return "\n".join(["%s" % item for item in inp.strip(".").split(".")])
 
 # 按标点符号切
@@ -134,7 +122,7 @@ def cut4(inp):
 def cut5(inp):
     # if not re.search(r'[^\w\s]', inp[-1]):
     # inp += '。'
-    inp = inp.strip("\n")
+    inp = split_big_text(inp).strip("\n")
     punds = r'[,.;?!、，。？！;：…]'
     items = re.split(f'({punds})', inp)
     mergeitems = ["".join(group) for group in zip(items[::2], items[1::2])]
@@ -144,9 +132,67 @@ def cut5(inp):
     opt = "\n".join(mergeitems)
     return opt
 
+# contributed by https://github.com/X-T-E-R/GPT-SoVITS-Inference/blob/main/GPT_SoVITS/TTS_infer_pack/text_segmentation_method.py
+@register_method("auto_cut")
+def auto_cut(inp, max_length=60):
+    # if not re.search(r'[^\w\s]', inp[-1]):
+    # inp += '。'
+    inp = inp.strip("\n")
+    erase_punds = r'[“”"‘’\'（）()【】[\]{}<>《》〈〉〔〕〖〗〘〙〚〛〛〞〟]'
+    inp = re.sub(erase_punds, '', inp)
+    split_punds = r'[?!。？！~：]'
+    if inp[-1] not in split_punds:
+        inp+="。"
+    items = re.split(f'({split_punds})', inp)
+    items = ["".join(group) for group in zip(items[::2], items[1::2])]
+
+    def process_commas(text, max_length):
+    
+        # Define separators and the regular expression for splitting
+        separators = ['，', ',', '、', '——', '…']
+        # 使用正则表达式的捕获组来保留分隔符，分隔符两边的括号就是所谓的捕获组
+        regex_pattern = '(' + '|'.join(map(re.escape, separators)) + ')'
+        # 使用re.split函数分割文本，由于使用了捕获组，分隔符也会作为分割结果的一部分返回
+        sentences = re.split(regex_pattern, text)
+  
+        processed_text = "" 
+        current_line = "" 
+        
+        final_sentences = []
+        
+        for sentence in sentences:
+            if len(sentence)>max_length:
+                
+                final_sentences+=split_big_text(sentence,max_length=max_length).split("\n")
+            else:
+                final_sentences.append(sentence)
+        
+        for sentence in final_sentences:
+            # Add the length of the sentence plus one for the space or newline that will follow
+            if len(current_line) + len(sentence) <= max_length:
+                # If adding the next sentence does not exceed max length, add it to the current line
+                current_line += sentence
+            else:
+                # If the current line is too long, start a new line
+                processed_text += current_line.strip() + '\n'
+                current_line = sentence + " "  # Start the new line with the current sentence
+        
+        # Add any remaining text in current_line to processed_text
+        processed_text += current_line.strip()
+
+        return processed_text
+
+    final_items = []
+    for item in items:
+        final_items+=process_commas(item,max_length=max_length).split("\n")
+    
+    final_items = [item for item in final_items if item.strip() and not (len(item.strip()) == 1 and item.strip() in "?!，,。？！~：")]
+
+    return "\n".join(final_items)
 
 
 if __name__ == '__main__':
-    method = get_method("cut5")
-    print(method("你好，我是小明。你好，我是小红。你好，我是小刚。你好，我是小张。"))
-    
+    method = get_method("cut0")
+    str1="""一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十
+    """
+    print("|\n|".join(method(str1).split("\n")))

--- a/GPT_SoVITS/inference_webui.py
+++ b/GPT_SoVITS/inference_webui.py
@@ -64,6 +64,7 @@ cut_method = {
     i18n("按中文句号。切"): "cut3",
     i18n("按英文句号.切"): "cut4",
     i18n("按标点符号切"): "cut5",
+    i18n("基于标点凑字切"): "auto_cut",
 }
 
 tts_config = TTS_Config("GPT_SoVITS/configs/tts_infer.yaml")

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,5 @@ PyYAML
 psutil
 jieba_fast
 jieba
-LangSegment>=0.2.0
+LangSegment>=0.2.5
 Faster_Whisper


### PR DESCRIPTION
如题，当单句过长会导致爆显存
但是现在的代码没有用到split_big_text这个函数

实例：
```
一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十
```
这个用现行的切分方法都会退化成不切

因此重写了split_big_text，并且添加了一个新的切分方法：基于标点凑字切

这样就可以在以大标点如句号、问号划定的基础上，以小标点如逗号为划定的单位，囊括进尽可能多的短句了