### PR TITLE
Add use_distributed_sampler=False in Trainer

### DIFF
--- a/GPT_SoVITS/s1_train.py
+++ b/GPT_SoVITS/s1_train.py
@@ -132,6 +132,7 @@ def main(args):
         logger=logger,
         num_sanity_val_steps=0,
         callbacks=[ckpt_callback],
+        use_distributed_sampler=False,  # 非常简单的修改，但解决了采用自定义的 bucket_sampler 下训练步数不一致的问题！
     )
 
     model: Text2SemanticLightningModule = Text2SemanticLightningModule(


### PR DESCRIPTION
if you have defined your own sampler, you should have to set use_distributed_sampler to False! 当使用自定义的 sampler 时，必须设置 use_distributed_sampler 为 False