### PR TITLE
修改Faster-Whisper模型默认下载C盘目录的问题

### DIFF
--- a/tools/asr/fasterwhisper_asr.py
+++ b/tools/asr/fasterwhisper_asr.py
@@ -47,7 +47,7 @@ def execute_asr(input_folder, output_folder, model_size, language,precision):
     print("loading faster whisper model:",model_size,model_path)
     device = 'cuda' if torch.cuda.is_available() else 'cpu'
     try:
-        model = WhisperModel(model_path, device=device, compute_type=precision)
+        model = WhisperModel(model_path, device=device, compute_type=precision,download_root="./tools/asr/models",local_files_only=False)
     except:
         return print(traceback.format_exc())
     output = []


### PR DESCRIPTION
当前的版本在Windows下测试，如果whisper模型不存在，会在C:\Users\用户名\.cache\huggingface\hub下载模型，占用C盘空间