### PR TITLE
修复了Docker部署的GPT模型路径映射。

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,7 @@ services:
     volumes:
       - ./output:/workspace/output
       - ./logs:/workspace/logs
+      - ./GPT_weights:/workspace/GPT_weights
       - ./SoVITS_weights:/workspace/SoVITS_weights
       - ./reference:/workspace/reference
     working_dir: /workspace


### PR DESCRIPTION
在使用docker进行部署的时候，`GPT`模型被存放在`GPT_weights`下， 但是宿主机没有和容器进行对应的磁盘挂载，从而导致上传新的GPT模型不方便， 这个PR修复了这个问题。