### PR TITLE
[ASR] 修复FasterWhisper遍历输入路径失败

### DIFF
--- a/tools/asr/fasterwhisper_asr.py
+++ b/tools/asr/fasterwhisper_asr.py
@@ -2,14 +2,14 @@ import argparse
 import os
 import traceback
 
+os.environ["HF_ENDPOINT"]          = "https://hf-mirror.com"
+os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"
+
 import torch
 from faster_whisper import WhisperModel
 from tqdm import tqdm
 
 from tools.asr.config import check_fw_local_models
-
-os.environ["HF_ENDPOINT"]          = "https://hf-mirror.com"
-os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"
 
 language_code_list = [
     "af", "am", "ar", "as", "az", 

--- a/tools/asr/fasterwhisper_asr.py
+++ b/tools/asr/fasterwhisper_asr.py
@@ -1,17 +1,15 @@
 import argparse
 import os
-os.environ["HF_ENDPOINT"]="https://hf-mirror.com"
 import traceback
-import requests
-from glob import glob
-import torch
 
+import torch
 from faster_whisper import WhisperModel
 from tqdm import tqdm
 
 from tools.asr.config import check_fw_local_models
 
-os.environ["KMP_DUPLICATE_LIB_OK"]="TRUE"
+os.environ["HF_ENDPOINT"]          = "https://hf-mirror.com"
+os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"
 
 language_code_list = [
     "af", "am", "ar", "as", "az", 
@@ -36,7 +34,7 @@ language_code_list = [
     "vi", "yi", "yo", "zh", "yue",
     "auto"]
 
-def execute_asr(input_folder, output_folder, model_size, language,precision):
+def execute_asr(input_folder, output_folder, model_size, language, precision):
     if '-local' in model_size:
         model_size = model_size[:-6]
         model_path = f'tools/asr/models/faster-whisper-{model_size}'
@@ -50,17 +48,18 @@ def execute_asr(input_folder, output_folder, model_size, language,precision):
         model = WhisperModel(model_path, device=device, compute_type=precision)
     except:
         return print(traceback.format_exc())
+    
+    input_file_names = os.listdir(input_folder)
+    input_file_names.sort()
+
     output = []
     output_file_name = os.path.basename(input_folder)
-    output_file_path = os.path.abspath(f'{output_folder}/{output_file_name}.list')
-
-    if not os.path.exists(output_folder):
-        os.makedirs(output_folder)
-
-    for file in tqdm(glob(os.path.join(input_folder, '**/*.wav'), recursive=True)):
+    
+    for file_name in tqdm(input_file_names):
         try:
+            file_path = os.path.join(input_folder, file_name)
             segments, info = model.transcribe(
-                audio          = file,
+                audio          = file_path,
                 beam_size      = 5,
                 vad_filter     = True,
                 vad_parameters = dict(min_silence_duration_ms=700),
@@ -68,18 +67,23 @@ def execute_asr(input_folder, output_folder, model_size, language,precision):
             text = ''
 
             if info.language == "zh":
-                print("检测为中文文本,转funasr处理")
+                print("检测为中文文本, 转 FunASR 处理")
                 if("only_asr"not in globals()):
-                    from tools.asr.funasr_asr import only_asr##如果用英文就不需要导入下载模型
-                text = only_asr(file)
+                    from tools.asr.funasr_asr import \
+                        only_asr  # #如果用英文就不需要导入下载模型
+                text = only_asr(file_path)
 
             if text == '':
                 for segment in segments:
                     text += segment.text
-            output.append(f"{file}|{output_file_name}|{info.language.upper()}|{text}")
+            output.append(f"{file_path}|{output_file_name}|{info.language.upper()}|{text}")
         except:
             return print(traceback.format_exc())
-        
+    
+    output_folder = output_folder or "output/asr_opt"
+    os.makedirs(output_folder, exist_ok=True)
+    output_file_path = os.path.abspath(f'{output_folder}/{output_file_name}.list')
+
     with open(output_file_path, "w", encoding="utf-8") as f:
         f.write("\n".join(output))
         print(f"ASR 任务完成->标注文件路径: {output_file_path}\n")

--- a/tools/asr/funasr_asr.py
+++ b/tools/asr/funasr_asr.py
@@ -38,10 +38,11 @@ def execute_asr(input_folder, output_folder, model_size, language):
     output = []
     output_file_name = os.path.basename(input_folder)
 
-    for name in tqdm(input_file_names):
+    for file_name in tqdm(input_file_names):
         try:
-            text = model.generate(input="%s/%s"%(input_folder, name))[0]["text"]
-            output.append(f"{input_folder}/{name}|{output_file_name}|{language.upper()}|{text}")
+            file_path = os.path.join(input_folder, file_name)
+            text = model.generate(input=file_path)[0]["text"]
+            output.append(f"{file_path}|{output_file_name}|{language.upper()}|{text}")
         except:
             print(traceback.format_exc())
 


### PR DESCRIPTION
问题描述： #955
问题定位：faster whisper 用 glob 进行文件匹配，路径含特殊字符时未进行转义，导致无法遍历音频文件.
解决方案：换成 FunASR 使用的 `os.listdir`.

其他：
- [x] 和 FunASR 函数的代码进行对齐。
- [x] 去掉无效 import