### PR TITLE
在colab中运行colab_webui.ipynb发生的uvr5模型缺失问题

### DIFF
--- a/colab_webui.ipynb
+++ b/colab_webui.ipynb
@@ -67,6 +67,7 @@
         "!git clone https://www.modelscope.cn/damo/punc_ct-transformer_zh-cn-common-vocab272727-pytorch.git\n",
         "# @title UVR5 pretrains 安装uvr5模型\n",
         "%cd /content/GPT-SoVITS/tools/uvr5\n",
+        "%rm -r uvr5_weights\n"，
         "!git clone https://huggingface.co/Delik/uvr5_weights\n",
         "!git config core.sparseCheckout true\n",
         "!mv /content/GPT-SoVITS/GPT_SoVITS/pretrained_models/GPT-SoVITS/* /content/GPT-SoVITS/GPT_SoVITS/pretrained_models/"


### PR DESCRIPTION
在colab中使用git下载uvr5模型时报错
 `fatal: destination path 'uvr5_weights' already exists and is not an empty directory.`
通过在下载前将原本从本仓库下载的uvr5_weights文件夹删除可以解决问题。