### PR TITLE
Traceback (most recent call last):   File "/Users/wangxiaowei19/Study/GPT/GPT-SoVITS/webui.py", line 872, in <module>     app.queue(concurrency_count=511, max_size=1022).launch(   File "/usr/local/lib/python3.9/site-packages/gradio/blocks.py", line 2012, in queue     raise DeprecationWarning( DeprecationWarning: concurrency_count has been deprecated. Set the concurrency_limit directly on event listeners e.g. btn.click(fn, ..., concurrency_limit=10) or gr.Interface(concurrency_limit=10). If necessary, the total number of workers can be configured via `max_threads` in launch().

### DIFF
--- a/GPT_SoVITS/inference_webui.py
+++ b/GPT_SoVITS/inference_webui.py
@@ -613,7 +613,7 @@ with gr.Blocks(title="GPT-SoVITS WebUI") as app:
             button5.click(cut5, [text_inp], [text_opt])
         gr.Markdown(value=i18n("后续将支持转音素、手工修改音素、语音合成分步执行。"))
 
-app.queue(concurrency_count=511, max_size=1022).launch(
+app.queue().launch(
     server_name="0.0.0.0",
     inbrowser=True,
     share=is_share,

--- a/webui.py
+++ b/webui.py
@@ -869,7 +869,7 @@ with gr.Blocks(title="GPT-SoVITS WebUI") as app:
                     tts_info = gr.Textbox(label=i18n("TTS推理WebUI进程输出信息"))
                     if_tts.change(change_tts_inference, [if_tts,bert_pretrained_dir,cnhubert_base_dir,gpu_number_1C,GPT_dropdown,SoVITS_dropdown], [tts_info])
         with gr.TabItem(i18n("2-GPT-SoVITS-变声")):gr.Markdown(value=i18n("施工中，请静候佳音"))
-    app.queue(concurrency_count=511, max_size=1022).launch(
+    app.queue().launch(
         server_name="0.0.0.0",
         inbrowser=True,
         share=is_share,


### PR DESCRIPTION
解决MAC运行报错的问题。
Traceback (most recent call last):
  File "/Users/wangxiaowei19/Study/GPT/GPT-SoVITS/webui.py", line 872, in <module>
    app.queue(concurrency_count=511, max_size=1022).launch(
  File "/usr/local/lib/python3.9/site-packages/gradio/blocks.py", line 2012, in queue
    raise DeprecationWarning(
DeprecationWarning: concurrency_count has been deprecated. Set the concurrency_limit directly on event listeners e.g. btn.click(fn, ..., concurrency_limit=10) or gr.Interface(concurrency_limit=10). If necessary, the total number of workers can be configured via `max_threads` in launch().