### PR TITLE
[优化] 1Aa-文本获取

### DIFF
--- a/GPT_SoVITS/prepare_datasets/1-get-text.py
+++ b/GPT_SoVITS/prepare_datasets/1-get-text.py
@@ -125,7 +125,6 @@ if os.path.exists(txt_path) == False:
                 print(f"\033[33m[Waring] The {language = } of {wav_name} is not supported for training.\033[0m")
         except:
             print(line, traceback.format_exc())
-    assert len(todo) > 0, f"\033[31m[Error] Part {i_part}: No data loaded from {inp_text}.\033[0m"
     process(todo, res)
     opt = []
     for name, phones, word2ph, norm_text in res:

--- a/GPT_SoVITS/prepare_datasets/1-get-text.py
+++ b/GPT_SoVITS/prepare_datasets/1-get-text.py
@@ -117,12 +117,15 @@ if os.path.exists(txt_path) == False:
         try:
             wav_name, spk_name, language, text = line.split("|")
             # todo.append([name,text,"zh"])
-            todo.append(
-                [wav_name, text, language_v1_to_language_v2.get(language, language)]
-            )
+            if language in language_v1_to_language_v2.keys():
+                todo.append(
+                    [wav_name, text, language_v1_to_language_v2.get(language, language)]
+                )
+            else:
+                print(f"\033[33m[Waring] The {language = } of {wav_name} is not supported for training.\033[0m")
         except:
             print(line, traceback.format_exc())
-
+    assert len(todo) > 0, f"\033[31m[Error] Part {i_part}: No data loaded from {inp_text}.\033[0m"
     process(todo, res)
     opt = []
     for name, phones, word2ph, norm_text in res:

--- a/GPT_SoVITS/prepare_datasets/1-get-text.py
+++ b/GPT_SoVITS/prepare_datasets/1-get-text.py
@@ -125,6 +125,7 @@ if os.path.exists(txt_path) == False:
                 print(f"\033[33m[Waring] The {language = } of {wav_name} is not supported for training.\033[0m")
         except:
             print(line, traceback.format_exc())
+
     process(todo, res)
     opt = []
     for name, phones, word2ph, norm_text in res:

--- a/webui.py
+++ b/webui.py
@@ -411,15 +411,14 @@ def open1a(inp_text,inp_wav_dir,exp_name,gpu_numbers,bert_pretrained_dir):
         opt = []
         for i_part in range(all_parts):
             txt_path = "%s/2-name2text-%s.txt" % (opt_dir, i_part)
-            if os.path.exists(txt_path):
-                with open(txt_path, "r", encoding="utf8") as f:
-                    opt += f.read().strip("\n").split("\n")
-                os.remove(txt_path)
+            with open(txt_path, "r", encoding="utf8") as f:
+                opt += f.read().strip("\n").split("\n")
+            os.remove(txt_path)
         path_text = "%s/2-name2text.txt" % opt_dir
         with open(path_text, "w", encoding="utf8") as f:
             f.write("\n".join(opt) + "\n")
         ps1a=[]
-        if len(opt) > 0:
+        if len("".join(opt)) > 0:
             yield "文本进程成功", {"__type__": "update", "visible": True}, {"__type__": "update", "visible": False}
         else:
             yield "文本进程失败", {"__type__": "update", "visible": True}, {"__type__": "update", "visible": False}
@@ -582,13 +581,12 @@ def open1abc(inp_text,inp_wav_dir,exp_name,gpu_numbers1a,gpu_numbers1Ba,gpu_numb
                 opt = []
                 for i_part in range(all_parts):#txt_path="%s/2-name2text-%s.txt"%(opt_dir,i_part)
                     txt_path = "%s/2-name2text-%s.txt" % (opt_dir, i_part)
-                    if os.path.exists(txt_path):
-                        with open(txt_path, "r",encoding="utf8") as f:
-                            opt += f.read().strip("\n").split("\n")
-                        os.remove(txt_path)
+                    with open(txt_path, "r",encoding="utf8") as f:
+                        opt += f.read().strip("\n").split("\n")
+                    os.remove(txt_path)
                 with open(path_text, "w",encoding="utf8") as f:
                     f.write("\n".join(opt) + "\n")
-            assert len(opt) > 0, "1Aa-文本获取进程失败"
+            assert len("".join(opt)) > 0, "1Aa-文本获取进程失败"
             yield "进度：1a-done", {"__type__": "update", "visible": False}, {"__type__": "update", "visible": True}
             ps1abc=[]
             #############################1b

--- a/webui.py
+++ b/webui.py
@@ -411,9 +411,10 @@ def open1a(inp_text,inp_wav_dir,exp_name,gpu_numbers,bert_pretrained_dir):
         opt = []
         for i_part in range(all_parts):
             txt_path = "%s/2-name2text-%s.txt" % (opt_dir, i_part)
-            with open(txt_path, "r", encoding="utf8") as f:
-                opt += f.read().strip("\n").split("\n")
-            os.remove(txt_path)
+            if os.path.exists(txt_path):
+                with open(txt_path, "r", encoding="utf8") as f:
+                    opt += f.read().strip("\n").split("\n")
+                os.remove(txt_path)
         path_text = "%s/2-name2text.txt" % opt_dir
         with open(path_text, "w", encoding="utf8") as f:
             f.write("\n".join(opt) + "\n")

--- a/webui.py
+++ b/webui.py
@@ -586,7 +586,7 @@ def open1abc(inp_text,inp_wav_dir,exp_name,gpu_numbers1a,gpu_numbers1Ba,gpu_numb
                     os.remove(txt_path)
                 with open(path_text, "w",encoding="utf8") as f:
                     f.write("\n".join(opt) + "\n")
-            assert len("".join(opt)) > 0, "1Aa-文本获取进程失败"
+                assert len("".join(opt)) > 0, "1Aa-文本获取进程失败"
             yield "进度：1a-done", {"__type__": "update", "visible": False}, {"__type__": "update", "visible": True}
             ps1abc=[]
             #############################1b

--- a/webui.py
+++ b/webui.py
@@ -419,7 +419,10 @@ def open1a(inp_text,inp_wav_dir,exp_name,gpu_numbers,bert_pretrained_dir):
         with open(path_text, "w", encoding="utf8") as f:
             f.write("\n".join(opt) + "\n")
         ps1a=[]
-        yield "文本进程结束",{"__type__":"update","visible":True},{"__type__":"update","visible":False}
+        if len(opt) > 0:
+            yield "文本进程成功", {"__type__": "update", "visible": True}, {"__type__": "update", "visible": False}
+        else:
+            yield "文本进程失败", {"__type__": "update", "visible": True}, {"__type__": "update", "visible": False}
     else:
         yield "已有正在进行的文本任务，需先终止才能开启下一次任务", {"__type__": "update", "visible": False}, {"__type__": "update", "visible": True}
 
@@ -579,12 +582,13 @@ def open1abc(inp_text,inp_wav_dir,exp_name,gpu_numbers1a,gpu_numbers1Ba,gpu_numb
                 opt = []
                 for i_part in range(all_parts):#txt_path="%s/2-name2text-%s.txt"%(opt_dir,i_part)
                     txt_path = "%s/2-name2text-%s.txt" % (opt_dir, i_part)
-                    with open(txt_path, "r",encoding="utf8") as f:
-                        opt += f.read().strip("\n").split("\n")
-                    os.remove(txt_path)
+                    if os.path.exists(txt_path):
+                        with open(txt_path, "r",encoding="utf8") as f:
+                            opt += f.read().strip("\n").split("\n")
+                        os.remove(txt_path)
                 with open(path_text, "w",encoding="utf8") as f:
                     f.write("\n".join(opt) + "\n")
-
+            assert len(opt) > 0, "1Aa-文本获取进程失败"
             yield "进度：1a-done", {"__type__": "update", "visible": False}, {"__type__": "update", "visible": True}
             ps1abc=[]
             #############################1b


### PR DESCRIPTION
相关 Issue: #1099

> [!Note]
> ### 过滤掉标注文件中语言不受支持的数据.
> 修改 `prepare_datasets/1-get-text.py`:
> - 获取文本时过滤掉字典 `language_v1_to_language_v2` 不支持的语言类型, 添加 Warning 提示.
>
> ### 优化 WebUI 相应部分的反馈, 
> 修改 `webui.py`:
> - 点击 `开启文本获取` 和 `一键三连` 时, 判断输出结果拼接后的长度是否大于 0, 不大于 0 则表示文本获取失败.
>

修改效果示例: 

![image](https://github.com/RVC-Boss/GPT-SoVITS/assets/36986837/3847353c-c3da-40e8-b9d5-bd1a41647462)

> [!Warning]
> - [ ] 建议: 添加全局日志, 方便后续修改?