### PR TITLE
添加一键部署到阿里云函数计算的链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ https://github.com/RVC-Boss/GPT-SoVITS/assets/129054828/05bee1fa-bdd8-4d85-9350-
 
 For users in China region, you can [click here](https://www.codewithgpu.com/i/RVC-Boss/GPT-SoVITS/GPT-SoVITS-Official) to use AutoDL Cloud Docker to experience the full functionality online.
 
-You can also deploy on [Alibaba Cloud Function Compute](https://www.alibabacloud.com/en/product/function-compute) by [clicking here](https://fcnext.console.aliyun.com/applications/create?template=fc-gpt-sovits).
+You can also deploy on [Alibaba Cloud Function Compute](https://www.alibabacloud.com/en/product/function-compute) by [clicking here](https://fcnext.console.aliyun.com/applications/ai/create?template=fc-gpt-sovits).
 
 ### Tested Environments
 

--- a/docs/cn/README.md
+++ b/docs/cn/README.md
@@ -39,8 +39,8 @@ https://github.com/RVC-Boss/GPT-SoVITS/assets/129054828/05bee1fa-bdd8-4d85-9350-
 
 中国地区用户可[点击此处](https://www.codewithgpu.com/i/RVC-Boss/GPT-SoVITS/GPT-SoVITS-Official)使用 AutoDL 云端镜像进行体验。
 
-还可以通过通过阿里云 [Serverless 应用中心](https://fcnext.console.aliyun.com/applications/create?template=fc-gpt-sovits) ，
-  [![Deploy with Severless Devs](https://img.alicdn.com/imgextra/i1/O1CN01w5RFbX1v45s8TIXPz_!!6000000006118-55-tps-95-28.svg)](https://fcnext.console.aliyun.com/applications/create?template=fc-gpt-sovits) 到云端进行体验。
+还可以通过通过阿里云 [Serverless 应用中心](https://fcnext.console.aliyun.com/applications/ai/create?template=fc-gpt-sovits) ，
+  [![Deploy with Severless Devs](https://img.alicdn.com/imgextra/i1/O1CN01w5RFbX1v45s8TIXPz_!!6000000006118-55-tps-95-28.svg)](https://fcnext.console.aliyun.com/applications/ai/create?template=fc-gpt-sovits) 到云端进行体验。
 
 ### 测试通过的环境
 


### PR DESCRIPTION
基于原项目制作了一个阿里云函数计算的应用模版，可以实现：
1. 一键部署到阿里云函数计算。
2. 直接通过免费域名访问WebUI和API服务。
3. 按用计费，用了多少就花多少钱，摆脱按小时租gpu的时间浪费。
4. 训练的模型自动放在NAS，方便保存和下载。

代码上的修改主要是：
1. 大改了页面逻辑，把所有页面放在一起。
2. 简化训练流程，只需点点点。
3. 加了些模版参考音频，能快速生成。
4. 加入对阿里云NAS的支持。
5. API服务能指定模型（要放到NAS内）

修改后代码在：
https://github.com/zxypro1/GPT-SoVITS
阿里云和Serverless Devs部署用的应用模版IaC文件在：
https://github.com/devsapp/fc-gpt-sovits

## 文档
https://www.yuque.com/zxypro/mnayfw/nt5pdxbuukpzfos1

## 截图
TTS推理：
<img width="1528" alt="截屏2024-05-23 15 58 56" src="https://github.com/RVC-Boss/GPT-SoVITS/assets/43384183/36540776-de52-4181-bf03-fc08e606119d">
数据预处理：
<img width="1525" alt="截屏2024-05-23 15 59 06" src="https://github.com/RVC-Boss/GPT-SoVITS/assets/43384183/a26516dc-c5ea-4adf-aadd-14fa53806454">
数据校对：
<img width="1562" alt="截屏2024-05-23 15 59 14" src="https://github.com/RVC-Boss/GPT-SoVITS/assets/43384183/1724ce6b-c725-48e3-ae79-a90323696ed0">
微调：
<img width="1541" alt="截屏2024-05-23 15 59 21" src="https://github.com/RVC-Boss/GPT-SoVITS/assets/43384183/e5f7b96a-818a-4706-b29b-84018aba24ed">

