### PR TITLE
修复过时的 concurrency_count 参数引发的问题

### DIFF
--- a/GPT_SoVITS/inference_webui.py
+++ b/GPT_SoVITS/inference_webui.py
@@ -613,7 +613,8 @@ with gr.Blocks(title="GPT-SoVITS WebUI") as app:
             button5.click(cut5, [text_inp], [text_opt])
         gr.Markdown(value=i18n("后续将支持转音素、手工修改音素、语音合成分步执行。"))
 
-app.queue(concurrency_count=511, max_size=1022).launch(
+app.queue(max_size=1022).launch(
+    max_threads=511,
     server_name="0.0.0.0",
     inbrowser=True,
     share=is_share,

--- a/tools/uvr5/webui.py
+++ b/tools/uvr5/webui.py
@@ -167,7 +167,8 @@ with gr.Blocks(title="UVR5 WebUI") as app:
                         [vc_output4],
                         api_name="uvr_convert",
                     )
-app.queue(concurrency_count=511, max_size=1022).launch(
+app.queue(max_size=1022).launch(
+    max_threads=511,
     server_name="0.0.0.0",
     inbrowser=True,
     share=is_share,

--- a/webui.py
+++ b/webui.py
@@ -872,7 +872,8 @@ with gr.Blocks(title="GPT-SoVITS WebUI") as app:
                     tts_info = gr.Textbox(label=i18n("TTS推理WebUI进程输出信息"))
                     if_tts.change(change_tts_inference, [if_tts,bert_pretrained_dir,cnhubert_base_dir,gpu_number_1C,GPT_dropdown,SoVITS_dropdown], [tts_info])
         with gr.TabItem(i18n("2-GPT-SoVITS-变声")):gr.Markdown(value=i18n("施工中，请静候佳音"))
-    app.queue(concurrency_count=511, max_size=1022).launch(
+    app.queue(max_size=1022).launch(
+        max_threads=511,
         server_name="0.0.0.0",
         inbrowser=True,
         share=is_share,


### PR DESCRIPTION
随着 `gradio` 的更新，`concurrency_count` 参数已经被废弃，此 PR 按照异常信息中的建议更改了相关参数，修复了相关问题。