### PR TITLE
使用更安全的逻辑判断代替eval()

### DIFF
--- a/GPT_SoVITS/inference_webui.py
+++ b/GPT_SoVITS/inference_webui.py
@@ -45,8 +45,7 @@ bert_path = os.environ.get(
 )
 infer_ttswebui = os.environ.get("infer_ttswebui", 9872)
 infer_ttswebui = int(infer_ttswebui)
-is_share = os.environ.get("is_share", "False")
-is_share = eval(is_share)
+is_share = os.environ.get("is_share", "False").lower() == "true"
 if "_CUDA_VISIBLE_DEVICES" in os.environ:
     os.environ["CUDA_VISIBLE_DEVICES"] = os.environ["_CUDA_VISIBLE_DEVICES"]
 is_half = eval(os.environ.get("is_half", "True")) and torch.cuda.is_available()

--- a/GPT_SoVITS/prepare_datasets/1-get-text.py
+++ b/GPT_SoVITS/prepare_datasets/1-get-text.py
@@ -10,7 +10,7 @@ all_parts = os.environ.get("all_parts")
 os.environ["CUDA_VISIBLE_DEVICES"] = os.environ.get("_CUDA_VISIBLE_DEVICES")
 opt_dir = os.environ.get("opt_dir")
 bert_pretrained_dir = os.environ.get("bert_pretrained_dir")
-is_half = eval(os.environ.get("is_half", "True"))
+is_half = os.environ.get("is_half", "True").lower() == "true"
 import sys, numpy as np, traceback, pdb
 import os.path
 from glob import glob

--- a/GPT_SoVITS/prepare_datasets/2-get-hubert-wav32k.py
+++ b/GPT_SoVITS/prepare_datasets/2-get-hubert-wav32k.py
@@ -10,7 +10,7 @@ os.environ["CUDA_VISIBLE_DEVICES"]= os.environ.get("_CUDA_VISIBLE_DEVICES")
 from feature_extractor import cnhubert
 opt_dir=                            os.environ.get("opt_dir")
 cnhubert.cnhubert_base_path=                os.environ.get("cnhubert_base_dir")
-is_half=eval(os.environ.get("is_half","True"))
+is_half=os.environ.get("is_half","True").lower()=="true"
 
 import pdb,traceback,numpy as np,logging
 from scipy.io import wavfile

--- a/GPT_SoVITS/prepare_datasets/3-get-semantic.py
+++ b/GPT_SoVITS/prepare_datasets/3-get-semantic.py
@@ -8,7 +8,7 @@ os.environ["CUDA_VISIBLE_DEVICES"] = os.environ.get("_CUDA_VISIBLE_DEVICES")
 opt_dir = os.environ.get("opt_dir")
 pretrained_s2G = os.environ.get("pretrained_s2G")
 s2config_path = os.environ.get("s2config_path")
-is_half = eval(os.environ.get("is_half", "True"))
+is_half = os.environ.get("is_half", "True").lower() == "true"
 import math, traceback
 import multiprocessing
 import sys, pdb

--- a/tools/subfix_webui.py
+++ b/tools/subfix_webui.py
@@ -493,6 +493,6 @@ if __name__ == "__main__":
         server_name="0.0.0.0",
         inbrowser=True,
         quiet=True,
-        share=eval(args.is_share),
+        share=args.is_share.lower() == "true",
         server_port=int(args.webui_port_subfix)
     )

--- a/tools/uvr5/webui.py
+++ b/tools/uvr5/webui.py
@@ -19,9 +19,9 @@ for name in os.listdir(weight_uvr5_root):
         uvr5_names.append(name.replace(".pth", ""))
 
 device=sys.argv[1]
-is_half=eval(sys.argv[2])
+is_half=sys.argv[2].lower() == "true"
 webui_port_uvr5=int(sys.argv[3])
-is_share=eval(sys.argv[4])
+is_share=sys.argv[4].lower() == "true"
 
 def uvr(model_name, inp_root, save_root_vocal, paths, save_root_ins, agg, format0):
     infos = []


### PR DESCRIPTION
# 使用更安全的逻辑判断代替 `eval()`

## 原因

直接使用 `eval()` 函数执行用户输入或命令行参数是非常不安全的，因为它可以执行任意代码，可能导致安全漏洞，如代码注入攻击。

## 实例

``` python
is_share=eval(sys.argv[4])
```

``` python
is_share = sys.argv[4].lower() == 'true'
```

参数只会是"True"或"False"，可以使用更安全的逻辑判断代替 `eval()`。
