### PR TITLE
fix: 修复prompt_cache里面没有cache住ref_audio_path带来的无效耗时

### DIFF
--- a/GPT_SoVITS/TTS_infer_pack/TTS.py
+++ b/GPT_SoVITS/TTS_infer_pack/TTS.py
@@ -360,7 +360,11 @@ class TTS:
         '''
         self._set_prompt_semantic(ref_audio_path)
         self._set_ref_spec(ref_audio_path)
+        self._set_ref_audio_path(ref_audio_path)
         
+    def _set_ref_audio_path(self, ref_audio_path):
+        self.prompt_cache["ref_audio_path"] = ref_audio_path 
+
     def _set_ref_spec(self, ref_audio_path):
         audio = load_audio(ref_audio_path, int(self.configs.sampling_rate))
         audio = torch.FloatTensor(audio)


### PR DESCRIPTION
修复prompt_cache里面没有cache住ref_audio_path，导致每次TTS推理都需要加载一遍reference audio的bug：
- 首次音频帧从速度提升，从3.2s -> 1.7s