### PR TITLE
修正numba与numpy匹配问题，在ubuntu24.04下测试通过

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy==1.23.4
 scipy
 tensorboard
 librosa==0.9.2


### PR DESCRIPTION
指定numpy版本1.23.4，与numba==0.56.4匹配报错问题