### PR TITLE
Fix for AttributeError: 'NoneType' object has no attribute 'shape'

### DIFF
--- a/GPT_SoVITS/AR/models/t2s_model.py
+++ b/GPT_SoVITS/AR/models/t2s_model.py
@@ -528,6 +528,7 @@ class Text2SemanticDecoder(nn.Module):
             y_pos = None
             xy_pos = x
             y = torch.zeros(x.shape[0], 0, dtype=torch.int, device=x.device)
+            prompts = y
             ref_free = True
 
         x_attn_mask_pad = F.pad(


### PR DESCRIPTION
y is None at no reference mode, and Nonetype object has no attribute shape