### PR TITLE
重定向工作区目录为./GPT-SoVITS

### DIFF
--- a/tools/i18n/i18n.py
+++ b/tools/i18n/i18n.py
@@ -2,6 +2,10 @@ import json
 import locale
 import os
 
+# Get the directory where the script file is located
+script_dir = os.path.dirname(os.path.abspath(__file__))
+# Change the current working directory to the directory where the script is located
+os.chdir(os.path.join(script_dir,'../../'))
 
 def load_language_list(language):
     with open(f"./i18n/locale/{language}.json", "r", encoding="utf-8") as f:


### PR DESCRIPTION
windows下使用vscode连接linux服务器，不在项目目录下，直接点击run python file按钮运行代码，工作区位置错误找不到 ‘./i18n/locale/en_US.json’
![image](https://github.com/user-attachments/assets/c4788ee8-6191-40cc-83ab-e4988b567b57)

修改后在windows及windows本地连接linux服务器（mac未测试）均可打开WebUI

