### PR TITLE
fix TTS.py

### DIFF
--- a/GPT_SoVITS/TTS_infer_pack/TTS.py
+++ b/GPT_SoVITS/TTS_infer_pack/TTS.py
@@ -506,7 +506,7 @@ class TTS:
                     # norm_text = item["norm_text"]
 
                 bert_max_len = max(bert_max_len, all_bert_features.shape[-1])
-                phones_max_len = max(phones_max_len, phones.shape[-1])
+                phones_max_len = max(phones_max_len, all_phones.shape[-1])
                 
                 phones_list.append(phones)
                 phones_len_list.append(phones.shape[-1])


### PR DESCRIPTION
max_len = max(bert_max_len, phones_max_len)  
bert_max_len使用的是prompt_text+text的长度，
phones_max_len却是text的长度，修正为prompt_text+text的长度