### PR TITLE
fix webui.py python环境.pth问题修复

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -32,15 +32,12 @@ os.environ["no_proxy"] = "localhost, 127.0.0.1, ::1"
 os.environ["all_proxy"] = ""
 for site_packages_root in site_packages_roots:
     if os.path.exists(site_packages_root):
-        try:
-            with open("%s/users.pth" % (site_packages_root), "w") as f:
-                f.write(
-                    "%s\n%s/tools\n%s/tools/damo_asr\n%s/GPT_SoVITS\n%s/tools/uvr5"
-                    % (now_dir, now_dir, now_dir, now_dir, now_dir)
-                )
-            break
-        except PermissionError:
-            pass
+        for name in ["tools","tools/damo_asr","GPT_SoVITS","tools/uvr5"]:
+            if "PYTHONPATH" in os.environ:
+                os.environ["PYTHONPATH"] =  os.path.join(now_dir, name)+ os.pathsep + os.environ["PYTHONPATH"]
+            else:
+                os.environ["PYTHONPATH"] =  os.path.join(now_dir, name)+ os.pathsep
+sys.path = os.environ['PYTHONPATH'].split(os.pathsep) + sys.path
 from tools import my_utils
 import traceback
 import shutil


### PR DESCRIPTION
路径不需要写入site-packages下的.pth文件中，而是使用os.environ['PYTHONPATH']的方式写入，避免其他项目使用同一个python环境因路径问题产生报错