### PR TITLE
修复 无法监听双栈

### DIFF
--- a/api_v2.py
+++ b/api_v2.py
@@ -451,6 +451,8 @@ async def set_sovits_weights(weights_path: str = None):
 
 if __name__ == "__main__":
     try:
+        if host == 'None':   # 在调用时使用 -a None 参数，可以让api监听双栈
+            host = None
         uvicorn.run(app=APP, host=host, port=port, workers=1)
     except Exception as e:
         traceback.print_exc()


### PR DESCRIPTION
在调用时使用 -a None 参数，可以让 api 监听双栈