### PR TITLE
Add LLM translated CMUDICT-KATAKANA dictionary

### DIFF
--- a/GPT_SoVITS/text/japanese.py
+++ b/GPT_SoVITS/text/japanese.py
@@ -82,8 +82,9 @@ def post_replace_ph(ph):
         ph = rep_map[ph]
     # if ph in symbols:
     #     return ph
-    # if ph not in symbols:
-    #     ph = "UNK"
+    if ph not in symbols:
+        ph = "UNK"
+        # UNK may be useful as a pause token as it was trained in the model
     return ph
 
 
@@ -103,6 +104,8 @@ def symbols_to_japanese(text):
 def preprocess_jap(text, with_prosody=False):
     """Reference https://r9y9.github.io/ttslearn/latest/notebooks/ch10_Recipe-Tacotron.html"""
     text = symbols_to_japanese(text)
+    # English words to lower case, should have no influence on japanese words.
+    text = text.lower()
     sentences = re.split(_japanese_marks, text)
     marks = re.findall(_japanese_marks, text)
     text = []
@@ -219,5 +222,6 @@ def g2p(norm_text, with_prosody=True):
 
 
 if __name__ == "__main__":
-    phones = g2p("こんにちは, hello, AKITOです,よろしくお願いしますね！")
+    from text.symbols2 import symbols
+    phones = g2p("Hello.こんにちは！今日もNiCe天気ですね！tokyotowerに行きましょう！")
     print(phones)


### PR DESCRIPTION
This pull request introduces a CMUDICT-to-Katakana dictionary, translated using ChatGPT and DeepSeek. This conversion enables the Japanese G2P mode to directly pronounce most common English words in Katakana, improving the compatibility of English terms in Japanese tts applications.

Since the translation was performed by an LLM the accuracy might not be perfect and could benefit from further refinement. However, initial testing indicates that it is currently functional and applicable in most cases.

Additionally, this update restores the "UNK" token's phoneme. During training, this token was learned as a pause, which has shown to be helpful in the Japanese G2P process.