### PR TITLE
正确导入symbols模块

### DIFF
--- a/GPT_SoVITS/text/japanese.py
+++ b/GPT_SoVITS/text/japanese.py
@@ -1,6 +1,8 @@
 # modified from https://github.com/CjangCjengh/vits/blob/main/text/japanese.py
 import re
 
+from text.symbols2 import symbols
+
 import pyopenjtalk
 import os
 import hashlib
@@ -222,6 +224,5 @@ def g2p(norm_text, with_prosody=True):
 
 
 if __name__ == "__main__":
-    from text.symbols2 import symbols
     phones = g2p("Hello.こんにちは！今日もNiCe天気ですね！tokyotowerに行きましょう！")
     print(phones)


### PR DESCRIPTION
在[#1660](https://github.com/RVC-Boss/GPT-SoVITS/pull/1660) 中，`GPT-SoVITS/text/japanese.py`内启用了如下代码：

```python
if ph not in symbols:
        ph = "UNK"
```

但`symbols`模块并未被正确导入。