### PR TITLE
Fix bug in #1690

### DIFF
--- a/GPT_SoVITS/TTS_infer_pack/TextPreprocessor.py
+++ b/GPT_SoVITS/TTS_infer_pack/TextPreprocessor.py
@@ -119,12 +119,7 @@ class TextPreprocessor:
     def get_phones_and_bert(self, text:str, language:str, version:str, final:bool=False):
         if language in {"en", "all_zh", "all_ja", "all_ko", "all_yue"}:
             language = language.replace("all_","")
-            if language == "en":
-                LangSegment.setfilters(["en"])
-                formattext = " ".join(tmp["text"] for tmp in LangSegment.getTexts(text))
-            else:
-                # 因无法区别中日韩文汉字,以用户输入为准
-                formattext = text
+            formattext = text
             while "  " in formattext:
                 formattext = formattext.replace("  ", " ")
             if language == "zh":

--- a/GPT_SoVITS/TTS_infer_pack/TextPreprocessor.py
+++ b/GPT_SoVITS/TTS_infer_pack/TextPreprocessor.py
@@ -20,7 +20,7 @@ from tools.i18n.i18n import I18nAuto, scan_language_list
 language=os.environ.get("language","Auto")
 language=sys.argv[-1] if sys.argv[-1] in scan_language_list() else language
 i18n = I18nAuto(language=language)
-punctuation = set(['!', '?', '…', ',', '.', '-'," "])
+punctuation = set(['!', '?', '…', ',', '.', '-'])
 
 def get_first(text:str) -> str:
     pattern = "[" + "".join(re.escape(sep) for sep in splits) + "]"

--- a/GPT_SoVITS/TTS_infer_pack/text_segmentation_method.py
+++ b/GPT_SoVITS/TTS_infer_pack/text_segmentation_method.py
@@ -135,7 +135,7 @@ def cut3(inp):
 @register_method("cut4")
 def cut4(inp):
     inp = inp.strip("\n")
-    opts = ["%s" % item for item in inp.strip(".").split(".")]
+    opts = re.split(r'(?<!\d)\.(?!\d)', inp.strip("."))
     opts = [item for item in opts if not set(item).issubset(punctuation)]
     return "\n".join(opts)
 

--- a/GPT_SoVITS/text/english.py
+++ b/GPT_SoVITS/text/english.py
@@ -237,6 +237,7 @@ def text_normalize(text):
     text = normalize_numbers(text)
     text = ''.join(char for char in unicodedata.normalize('NFD', text)
                     if unicodedata.category(char) != 'Mn')  # Strip accents
+    text = re.sub("%", " percent", text) # 将 % 转化为 “percent”
     text = re.sub("[^ A-Za-z'.,?!\-]", "", text)
     text = re.sub(r"(?i)i\.e\.", "that is", text)
     text = re.sub(r"(?i)e\.g\.", "for example", text)

--- a/GPT_SoVITS/text/english.py
+++ b/GPT_SoVITS/text/english.py
@@ -22,6 +22,14 @@ CMU_DICT_HOT_PATH = os.path.join(current_file_path, "engdict-hot.rep")
 CACHE_PATH = os.path.join(current_file_path, "engdict_cache.pickle")
 NAMECACHE_PATH = os.path.join(current_file_path, "namedict_cache.pickle")
 
+rep_map = {
+        "[;:：，；]": ",",
+        '["’]': "'",
+        "。": ".",
+        "！": "!",
+        "？": "?",
+    }
+
 arpa = {
     "AH0",
     "S",
@@ -221,15 +229,9 @@ def get_namedict():
 def text_normalize(text):
     # todo: eng text normalize
     # 适配中文及 g2p_en 标点
-    rep_map = {
-        "[;:：，；]": ",",
-        '["’]': "'",
-        "。": ".",
-        "！": "!",
-        "？": "?",
-    }
-    for p, r in rep_map.items():
-        text = re.sub(p, r, text)
+    
+    pattern = re.compile("|".join(re.escape(p) for p in rep_map.keys()))
+    text = pattern.sub(lambda x: rep_map[x.group()], text)
 
     # 来自 g2p_en 文本格式化处理
     # 增加大写兼容

--- a/GPT_SoVITS/text/english.py
+++ b/GPT_SoVITS/text/english.py
@@ -30,6 +30,16 @@ rep_map = {
         "？": "?",
     }
 
+ordinal_map = {
+    "1. ": "First",
+    "2. ": "Second",
+    "3. ": "Third",
+    "4. ": "Fourth",
+    "5. ": "Fifth",
+    "6. ": "Sixth",
+    # 添加更多序数词映射
+}
+
 arpa = {
     "AH0",
     "S",
@@ -236,6 +246,9 @@ def text_normalize(text):
     # 来自 g2p_en 文本格式化处理
     # 增加大写兼容
     text = unicode(text)
+    for key, value in ordinal_map.items():
+        text = re.sub(rf"{re.escape(key)}\s?", value + ", ", text)
+        
     text = normalize_numbers(text)
     text = ''.join(char for char in unicodedata.normalize('NFD', text)
                     if unicodedata.category(char) != 'Mn')  # Strip accents


### PR DESCRIPTION
> 具体的修改说明可以参见这个问题下我的回答： #1690 

### 修复按英文句号.切分将句中数字（包含小数点）异常切分

在 GPT_SoVITS\TTS_infer_pack\text_segmentation_method.py 的 cut4 中：
```py
  @register_method("cut4")
  def cut4(inp):
      inp = inp.strip("\n")
      opts = ["%s" % item for item in inp.strip(".").split(".")]
      opts = [item for item in opts if not set(item).issubset(punctuation)]
      return "\n".join(opts)
```
修改其
```py
  opts = ["%s" % item for item in inp.strip(".").split(".")]
```
为：
```py
  opts = re.split(r'(?<!\d)\.(?!\d)', inp.strip("."))
```

使用正则表达式保证**只有前后都不是数字（也就是不是数字内包含的小数点）**是才进行切分

此外，还需要在 **...\GPT_SoVITS\TTS_infer_pack\TextPreprocessor.py** 中修改：

> 这里就是保证让输入的英文文本不去除句子结尾句号后面的空格，否则数字开头的句子和前面的句子不会切分开

```py
  language = os.environ.get("language", "Auto")
  language = sys.argv[-1] if sys.argv[-1] in scan_language_list() else language
  i18n = I18nAuto(language=language)
  punctuation = set(['!', '?', '…', ',', '.', '-', " "])
```
修改
```py
  punctuation = set(['!', '?', '…', ',', '.', '-', " "])
```
为
```py
  punctuation = set(['!', '?', '…', ',', '.', '-'])
```

去掉其中的“ ”（空格）；

为什么可以去掉？

 在 preprocess 函数中
```py
  text = self.replace_consecutive_punctuation(text) 
  texts = self.pre_seg_text(text, lang, text_split_method)
```
也就是在切分前先不去掉重复的空格，而在 pre_seg_text 中又调用了 filter_text 去掉无效的字符（比如空格），所以最后切分的文本还是正常的。个人理解，代码没看很全，有疏忽请多指教haha。

### 修复推理英文%未能正确读出

> 就是直接加了一个 `text = re.sub("%", " percent", text)` 在处理的时候把“%”替换了

在 **...\GPT_SoVITS\text\english.py** 中的 **text_normalize** 函数中，在
```py
  text = re.sub("[^ A-Za-z'.,?!\-]", "", text)
```
前添加：
```py
  text = re.sub("%", " percent", text)
```

### 一个 简单的测试：

目标文本：`hello.         123.45 is a          number. 23% should  be read as 23 percent.`

推理截图：

![test](https://github.com/user-attachments/assets/fc9c824e-385f-4ea5-ae34-3a8e171b7715)

生成语音：

https://github.com/user-attachments/assets/d19f7611-fe66-489a-8ab0-365ddc330d71

