### PR TITLE
指定字典读取编码，防止用户使用混合编码编辑器操作多音字字典或者英语热词字典后，报GBK编码错误

### DIFF
--- a/GPT_SoVITS/text/g2pw/g2pw.py
+++ b/GPT_SoVITS/text/g2pw/g2pw.py
@@ -127,14 +127,14 @@ def get_dict():
 
 def read_dict():
     polyphonic_dict = {}
-    with open(PP_DICT_PATH) as f:
+    with open(PP_DICT_PATH,encoding="utf-8") as f:
         line = f.readline()
         while line:
             key, value_str = line.split(':')
             value = eval(value_str.strip())
             polyphonic_dict[key.strip()] = value
             line = f.readline()
-    with open(PP_FIX_DICT_PATH) as f:
+    with open(PP_FIX_DICT_PATH,encoding="utf-8") as f:
         line = f.readline()
         while line:
             key, value_str = line.split(':')


### PR DESCRIPTION
指定字典读取编码，防止用户使用混合编码编辑器操作多音字字典或者英语热词字典后，报GBK编码错误