### PR TITLE
修复 chinese2.py 中 model_source 在训练时的路径获取问题

### DIFF
--- a/GPT_SoVITS/text/chinese2.py
+++ b/GPT_SoVITS/text/chinese2.py
@@ -27,7 +27,9 @@ if is_g2pw:
     print("当前使用g2pw进行拼音推理")
     from text.g2pw import G2PWPinyin, correct_pronunciation
     parent_directory = os.path.dirname(current_file_path)
-    g2pw = G2PWPinyin(model_dir="GPT_SoVITS/text/G2PWModel",model_source=os.environ.get("bert_path","GPT_SoVITS/pretrained_models/chinese-roberta-wwm-ext-large"),v_to_u=False, neutral_tone_with_five=True)
+    g2pw = G2PWPinyin(model_dir="GPT_SoVITS/text/G2PWModel",
+                      model_source=os.environ.get("bert_path") or os.environ.get("bert_pretrained_dir") or "GPT_SoVITS/pretrained_models/chinese-roberta-wwm-ext-large",
+                      v_to_u=False, neutral_tone_with_five=True)
 
 rep_map = {
     "：": ",",


### PR DESCRIPTION
之前的pr只修复了推理时的(`bert_path`)路径获取，这次把训练时的(`bert_pretrained_dir`)路径获取也给补上了。