### PR TITLE
Update inference_webui.py, 修复在Colab使用自行训练的v2模型时可能遇到的UnpicklingError: Weights only load failed.

### DIFF
--- a/GPT_SoVITS/inference_webui.py
+++ b/GPT_SoVITS/inference_webui.py
@@ -242,7 +242,7 @@ def change_sovits_weights(sovits_path,prompt_language=None,text_language=None):
             visible_inp_refs=True
         yield  {'__type__':'update', 'choices':list(dict_language.keys())}, {'__type__':'update', 'choices':list(dict_language.keys())}, prompt_text_update, prompt_language_update, text_update, text_language_update,{"__type__": "update", "visible": visible_sample_steps},{"__type__": "update", "visible": visible_inp_refs},{"__type__": "update", "value": False,"interactive":True if model_version!="v3"else False}
 
-    dict_s2 = torch.load(sovits_path, map_location="cpu")
+    dict_s2 = torch.load(sovits_path, map_location="cpu", weights_only=False)
     hps = dict_s2["config"]
     hps = DictToAttrRecursive(hps)
     hps.model.semantic_frame_rate = "25hz"


### PR DESCRIPTION
**修复在Colab使用自行训练的v2模型时可能遇到的UnpicklingError: Weights only load failed.**
大佬好！我在用colab端测试的时候发现以下问题以及解决方法：
![aa756c37-7090-46ad-b77b-4f8a8da569c3](https://github.com/user-attachments/assets/aced0688-c426-45f6-a1e1-0a1f55544cec)
我把本地训练好的V2模型文件丢到colab里想做推理测试，切换过去的时候出现了这样的状况。
![03226346-c577-4078-a2bb-f3ded601694d](https://github.com/user-attachments/assets/97aee245-200a-4812-9aa0-affef5bdc929)
地方应该是对的，但是报错
UnpicklingError: Weights only load failed. This file can still be loaded, to do so you have two options, do those steps only if you trust the source of the checkpoint. 
    (1) In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
    (2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.
    WeightsUnpickler error: Unsupported global: GLOBAL utils.HParams was not an allowed global by default. Please use `torch.serialization.add_safe_globals([HParams])` or the `torch.serialization.safe_globals([HParams])` context manager to allowlist this global if you trust this class/function.

在查看官网的documentation以后，我发现可以通过把inference_webui.py 245行`load`的时候改成
`    dict_s2 = torch.load(sovits_path, map_location="cpu", weights_only=False)`
加一个`weights_only=False`就能正常跑了
![image](https://github.com/user-attachments/assets/932928d7-b594-4054-9a03-a8e399f5cf7c)
![image](https://github.com/user-attachments/assets/007bb312-d277-4aa6-92cc-cb90d6a63608)
因而提出PR。
_- 官网上说要求如果weights_only=False的话可能有安全隐患，要求来源必须可靠。我寻思着colab或者自己端自己训练的话来源那肯定是可靠的，而且我本地现在也不会报这个错，所以就这么改了_

抱歉可能略有啰嗦，因为一想到真的可能有贡献人还是挺激动的。望大佬指正或merge，感谢！