### PR TITLE
CPU 使用更低 batch size

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -103,7 +103,7 @@ def set_default():
         gpu_info = ("%s\t%s" % ("0", "CPU"))
         gpu_infos.append("%s\t%s" % ("0", "CPU"))
         set_gpu_numbers.add(0)
-        default_batch_size = default_batch_size_s1=int(psutil.virtual_memory().total/ 1024 / 1024 / 1024 / 2)
+        default_batch_size = default_batch_size_s1 = max(1, int(psutil.virtual_memory().total / 1024 / 1024 / 1024 / 4))
     if version!="v3":
         default_sovits_epoch=8
         default_sovits_save_every_epoch=4

--- a/webui.py
+++ b/webui.py
@@ -103,7 +103,7 @@ def set_default():
         gpu_info = ("%s\t%s" % ("0", "CPU"))
         gpu_infos.append("%s\t%s" % ("0", "CPU"))
         set_gpu_numbers.add(0)
-        default_batch_size = default_batch_size_s1 = max(1, int(psutil.virtual_memory().total / 1024 / 1024 / 1024 / 4))
+        default_batch_size = default_batch_size_s1 = int(psutil.virtual_memory().total/ 1024 / 1024 / 1024 / 4)
     if version!="v3":
         default_sovits_epoch=8
         default_sovits_save_every_epoch=4
@@ -114,6 +114,9 @@ def set_default():
         default_sovits_save_every_epoch=1
         max_sovits_epoch=3
         max_sovits_save_every_epoch=3
+    
+    default_batch_size = max(1, default_batch_size)
+    default_batch_size_s1 = max(1, default_batch_size_s1)
     default_max_batch_size=default_batch_size*3
 
 set_default()


### PR DESCRIPTION
CPU 下 batch size 太高没意义，而且在 v3 版本下反而会导致内存占用过多，使系统压缩内存，导致训练速度降低，我这里甚至直接卡在一半了。所以统一降低到系统内存的四分之一