### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,4 @@ python_mecab_ko; sys_platform != 'win32'
 fastapi<0.112.2
 x_transformers
 torchmetrics<=1.5
+matplotlib<3.10


### PR DESCRIPTION
fix #1991

Matplotlib should be below version 3.10 to avoid AttributeError.

我可以复现，Matplotlib 最新版本是 3.10，其中移除了 tostring_rgb，导致在训练 v2 SoVITS 模型的时候出现 AttributeError: 'FigureCanvasAgg' object has no attribute 'tostring_rgb'. Did you mean: 'tostring_argb'?

降至 3.10 以下版本解决。