### PR TITLE
修复 Linux 无法编译 pyopenjtalk

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-conda install -c conda-forge gcc
+conda install -c conda-forge gcc=14
 conda install -c conda-forge gxx
 conda install ffmpeg cmake
 conda install pytorch==2.1.1 torchvision==0.16.1 torchaudio==2.1.1 pytorch-cuda=11.8 -c pytorch -c nvidia


### PR DESCRIPTION
一键安装脚本中 gcc 版本过高会使 pyopenjtalk 无法正常安装