### PR TITLE
fix: 修复 Linux 一键安装脚本执行失败问题

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,21 @@
 #!/bin/bash
+
+# 安装构建工具
+# Install build tools
 conda install -c conda-forge gcc=14
 conda install -c conda-forge gxx
 conda install ffmpeg cmake
+
+# 设置编译环境
+# Set up build environment
+export CMAKE_MAKE_PROGRAM="$CONDA_PREFIX/bin/cmake"
+export CC="$CONDA_PREFIX/bin/gcc"
+export CXX="$CONDA_PREFIX/bin/g++"
+
 conda install pytorch==2.1.1 torchvision==0.16.1 torchaudio==2.1.1 pytorch-cuda=11.8 -c pytorch -c nvidia
+
+# 刷新环境
+# Refresh environment
+hash -r
+
 pip install -r requirements.txt


### PR DESCRIPTION
安装 pyopenjtalk 库时不仅要保证 gcc 版本不高于 14，同时在执行 pip install -r requirements.txt 前需要保证环境变量中更新刚刚安装的 gcc/g++/cmake。 因此在安装三者后补充了设置环境变量，并且用 hash -r 确保生效

#2127 #1131 
@Chi8wah