### PR TITLE
[Fix] 为剩下文件做出修改，完善 `api.py` 对 `v3` 的适配支持，可直接运行使用

### DIFF
--- a/GPT_SoVITS/BigVGAN/bigvgan.py
+++ b/GPT_SoVITS/BigVGAN/bigvgan.py
@@ -14,6 +14,12 @@ import torch.nn as nn
 from torch.nn import Conv1d, ConvTranspose1d
 from torch.nn.utils import weight_norm, remove_weight_norm
 
+import sys
+
+# 确保工作目录包含该目录，否则无法导入 activations
+now_dir = os.getcwd()
+sys.path.append("%s/GPT_SoVITS/BigVGAN" % (now_dir))
+
 import activations
 from utils0 import init_weights, get_padding
 from alias_free_activation.torch.act import Activation1d as TorchActivation1d
@@ -431,7 +437,8 @@ class BigVGAN(
         """Load Pytorch pretrained weights and return the loaded model."""
 
         # Download and load hyperparameters (h) used by BigVGAN
-        if os.path.isdir(model_id):
+        isLocal = os.path.isdir(model_id)
+        if isLocal:
             # print("Loading config.json from local directory")
             config_file = os.path.join(model_id, "config.json")
         else:

--- a/GPT_SoVITS/text/LangSegmenter/langsegmenter.py
+++ b/GPT_SoVITS/text/LangSegmenter/langsegmenter.py
@@ -1,14 +1,22 @@
 import logging
 import re
 
+from pathlib import Path
+
 # jieba静音
 import jieba
 jieba.setLogLevel(logging.CRITICAL)
 
-# 更改fast_langdetect大模型位置
-from pathlib import Path
+# 加载配置
+import sys
+sys.path.append("..")
+from config import Config
+config = Config()
+
 import fast_langdetect
-fast_langdetect.infer._default_detector = fast_langdetect.infer.LangDetector(fast_langdetect.infer.LangDetectConfig(cache_dir=Path(__file__).parent.parent.parent / "pretrained_models" / "fast_langdetect"))
+# 更改fast_langdetect大模型位置
+if config.enable_costum_langdetect:
+    fast_langdetect.infer._default_detector = fast_langdetect.infer.LangDetector(fast_langdetect.infer.LangDetectConfig(cache_dir=Path(__file__).parent.parent.parent / "pretrained_models" / "fast_langdetect"))
 
 
 from split_lang import LangSplitter

--- a/api.py
+++ b/api.py
@@ -172,6 +172,8 @@ from tools.my_utils import load_audio
 import config as global_config
 import logging
 import subprocess
+from pathlib import Path
+import tqdm
 
 
 class DefaultRefer:
@@ -199,6 +201,12 @@ def is_full(*items):  # 任意一项为空返回False
 
 
 def init_bigvgan():
+    # 判断是否存在bigvgan模型 `nvidia/bigvgan_v2_24khz_100band_256x` 不存在则下载
+    if not (Path(__file__).parent / "GPT_SoVITS/pretrained_models/models--nvidia--bigvgan_v2_24khz_100band_256x").exists():
+        print("Downloading bigvgan model... from [nvidia/bigvgan_v2_24khz_100band_256x]")
+        from huggingface_hub import snapshot_download
+        snapshot_download(repo_id="nvidia/bigvgan_v2_24khz_100band_256x", repo_type="model", revision="main", cache_dir="GPT_SoVITS/pretrained_models")
+        
     global bigvgan_model
     from BigVGAN import bigvgan
     bigvgan_model = bigvgan.BigVGAN.from_pretrained("%s/GPT_SoVITS/pretrained_models/models--nvidia--bigvgan_v2_24khz_100band_256x" % (now_dir,), use_cuda_kernel=False)  # if True, RuntimeError: Ninja is required to load C++ extensions
@@ -363,7 +371,7 @@ def get_gpt_weights(gpt_path):
     gpt = Gpt(max_sec, t2s_model)
     return gpt
 
-def change_gpt_sovits_weights(gpt_path,sovits_path):
+def change_gpt_sovits_weights(gpt_path, sovits_path):
     try:
         gpt = get_gpt_weights(gpt_path)
         sovits = get_sovits_weights(sovits_path)

--- a/config.py
+++ b/config.py
@@ -15,6 +15,9 @@ bert_path = "GPT_SoVITS/pretrained_models/chinese-roberta-wwm-ext-large"
 pretrained_sovits_path = "GPT_SoVITS/pretrained_models/s2G488k.pth"
 pretrained_gpt_path = "GPT_SoVITS/pretrained_models/s1bert25hz-2kh-longer-epoch=68e-step=50232.ckpt"
 
+# 部分模型的启用
+enable_costum_langdetect = False
+
 exp_root = "logs"
 python_exec = sys.executable or "python"
 if torch.cuda.is_available():
@@ -53,6 +56,8 @@ class Config:
         self.bert_path = bert_path
         self.pretrained_sovits_path = pretrained_sovits_path
         self.pretrained_gpt_path = pretrained_gpt_path
+
+        self.enable_costum_langdetect = enable_costum_langdetect
 
         self.exp_root = exp_root
         self.python_exec = python_exec


### PR DESCRIPTION
# 🚀 完善 v3 适配
## 📕修改内容
- 添加 BigVGAN 工作目录，正确导入 activations
- 对模型 `nvidia/bigvgan_v2_24khz_100band_256x` 的下载进行补充
- 更改 `fast_langdetect` 的自定义为*可选项*

## ⭐ 结果
附运行成功截图（使用api.py，调用v3模型）：

<img width="1503" alt="8f335dfe75582854324c68381312bad" src="https://github.com/user-attachments/assets/b4ad1d10-1af5-4981-9888-398146f2ea7c" />

## 👀 Tips
启动参数如下，供参考：

```json
"args": [
    "-d", "cuda",
    "-dr", "ref_audio/Aris_MemorialLobby_5_2.ogg",
    "-dt", "先生と一緒にこの世界のことをもっと学びたいです！",
    "-dl", "ja",
    "-a", "127.0.0.1",
    "-p", "5980"
],
```

测试环境：
- 运行框架: `uv` 
- Python 版本: `cpython-3.10.16-windows-x86_64-none`
- CUDA 版本: `CUDA 12.6`
- 硬件环境如下图：

<img width="871" alt="19a30c1267500cb883365b93ce565ca" src="https://github.com/user-attachments/assets/d1b660cf-0910-47eb-bea5-52dd5da2f581" />
