### PR TITLE
Fix parameter assignment problem for DefaultRefer class

### DIFF
--- a/api.py
+++ b/api.py
@@ -176,9 +176,9 @@ import subprocess
 
 class DefaultRefer:
     def __init__(self, path, text, language):
-        self.path = args.default_refer_path
-        self.text = args.default_refer_text
-        self.language = args.default_refer_language
+        self.path = path
+        self.text = text
+        self.language = language
 
     def is_ready(self) -> bool:
         return is_full(self.path, self.text, self.language)


### PR DESCRIPTION
修复 api.py 中 DefaultRefer 类的参数赋值问题