### PR TITLE
Support Python 3.11, Clean Docs, and Update Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,14 @@ For users in China, you can [click here](https://www.codewithgpu.com/i/RVC-Boss/
 
 ### Tested Environments
 
-- Python 3.9, PyTorch 2.0.1, CUDA 11
-- Python 3.10.13, PyTorch 2.1.2, CUDA 12.3
-- Python 3.9, PyTorch 2.2.2, macOS 14.4.1 (Apple silicon)
-- Python 3.9, PyTorch 2.2.2, CPU devices
-
-_Note: numba==0.56.4 requires py<3.11_
+| Python Version | PyTorch Version  | Device          |
+|----------------|------------------|-----------------|
+| Python 3.9     | PyTorch 2.0.1    | CUDA 11.8       |
+| Python 3.10.13 | PyTorch 2.1.2    | CUDA 12.3       |
+| Python 3.10.17 | PyTorch 2.5.1    | CUDA 12.4       |
+| Python 3.9     | PyTorch 2.5.1    | Apple silicon   |
+| Python 3.11    | PyTorch 2.6.0    | Apple silicon   |
+| Python 3.9     | PyTorch 2.2.2    | CPU             |
 
 ### Windows
 
@@ -121,11 +123,11 @@ pip install -r requirements.txt
 
 #### docker-compose.yaml configuration
 
-0. Regarding image tags: Due to rapid updates in the codebase and the slow process of packaging and testing images, please check [Docker Hub](https://hub.docker.com/r/breakstring/gpt-sovits) for the currently packaged latest images and select as per your situation, or alternatively, build locally using a Dockerfile according to your own needs.
-1. Environment Variables：
+0. Regarding image tags: Due to rapid updates in the codebase and the slow process of packaging and testing images, please check [Docker Hub](https://hub.docker.com/r/breakstring/gpt-sovits)(outdated) for the currently packaged latest images and select as per your situation, or alternatively, build locally using a Dockerfile according to your own needs.
+1. Environment Variables: 
    - is_half: Controls half-precision/double-precision. This is typically the cause if the content under the directories 4-cnhubert/5-wav32k is not generated correctly during the "SSL extracting" step. Adjust to True or False based on your actual situation.
-2. Volumes Configuration，The application's root directory inside the container is set to /workspace. The default docker-compose.yaml lists some practical examples for uploading/downloading content.
-3. shm_size： The default available memory for Docker Desktop on Windows is too small, which can cause abnormal operations. Adjust according to your own situation.
+2. Volumes Configuration, The application's root directory inside the container is set to /workspace. The default docker-compose.yaml lists some practical examples for uploading/downloading content.
+3. shm_size: The default available memory for Docker Desktop on Windows is too small, which can cause abnormal operations. Adjust according to your own situation.
 4. Under the deploy section, GPU-related settings should be adjusted cautiously according to your system and actual circumstances.
 
 #### Running with docker compose
@@ -143,6 +145,8 @@ docker run --rm -it --gpus=all --env=is_half=False --volume=G:\GPT-SoVITS-Docker
 ```
 
 ## Pretrained Models
+
+**If `install.sh` runs successfully, you may skip No.1.**
 
 **Users in China can [download all these models here](https://www.yuque.com/baicaigongchang1145haoyuangong/ib3g1e/dkxgpiy9zb96hob4#nVNhX).**
 
@@ -258,7 +262,7 @@ Use v2 from v1 environment:
 
 3. Download v2 pretrained models from [huggingface](https://huggingface.co/lj1995/GPT-SoVITS/tree/main/gsv-v2final-pretrained) and put them into `GPT_SoVITS\pretrained_models\gsv-v2final-pretrained`.
 
-   Chinese v2 additional: [G2PWModel_1.1.zip](https://paddlespeech.cdn.bcebos.com/Parakeet/released_models/g2p/G2PWModel_1.1.zip)（Download G2PW models, unzip and rename to `G2PWModel`, and then place them in `GPT_SoVITS/text`.
+   Chinese v2 additional: [G2PWModel_1.1.zip](https://paddlespeech.cdn.bcebos.com/Parakeet/released_models/g2p/G2PWModel_1.1.zip)(Download G2PW models, unzip and rename to `G2PWModel`, and then place them in `GPT_SoVITS/text`.)
 
 ## V3 Release Notes
 

--- a/colab_webui.ipynb
+++ b/colab_webui.ipynb
@@ -30,10 +30,11 @@
         "!pip install -q condacolab\n",
         "# Setting up condacolab and installing packages\n",
         "import condacolab\n",
-        "condacolab.install_from_url(\"https://repo.anaconda.com/miniconda/Miniconda3-py39_23.11.0-2-Linux-x86_64.sh\")\n",
+        "condacolab.install_from_url(\"https://repo.anaconda.com/archive/Anaconda3-2024.10-1-Linux-x86_64.sh\")\n",
+        "\n",
         "%cd -q /content\n",
         "!git clone https://github.com/RVC-Boss/GPT-SoVITS\n",
-        "%cd -q /content/GPT-SoVITS\n",
+        "%cd -q GPT-SoVITS\n",
         "!bash install.sh"
       ]
     },
@@ -45,22 +46,12 @@
       },
       "outputs": [],
       "source": [
-        "# @title Download pretrained models 下载预训练模型\n",
-        "!mkdir -p /content/GPT-SoVITS/GPT_SoVITS/pretrained_models\n",
-        "!mkdir -p /content/GPT-SoVITS/tools/damo_asr/models\n",
-        "!mkdir -p /content/GPT-SoVITS/tools/uvr5\n",
-        "%cd /content/GPT-SoVITS/GPT_SoVITS/pretrained_models\n",
-        "!git clone https://huggingface.co/lj1995/GPT-SoVITS\n",
-        "%cd /content/GPT-SoVITS/tools/damo_asr/models\n",
-        "!git clone https://www.modelscope.cn/damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch.git\n",
-        "!git clone https://www.modelscope.cn/damo/speech_fsmn_vad_zh-cn-16k-common-pytorch.git\n",
-        "!git clone https://www.modelscope.cn/damo/punc_ct-transformer_zh-cn-common-vocab272727-pytorch.git\n",
-        "# @title UVR5 pretrains 安装uvr5模型\n",
-        "%cd /content/GPT-SoVITS/tools/uvr5\n",
-        "%rm -r uvr5_weights\n",
-        "!git clone https://huggingface.co/Delik/uvr5_weights\n",
-        "!git config core.sparseCheckout true\n",
-        "!mv /content/GPT-SoVITS/GPT_SoVITS/pretrained_models/GPT-SoVITS/* /content/GPT-SoVITS/GPT_SoVITS/pretrained_models/"
+        "# @title UVR5 Pretrained Models\n",
+        "!wget https://www.modelscope.cn/models/XXXXRT/UVR5Weights4GSV/resolve/master/uvr5_weights.zip\n",
+        "!unzip uvr5_weights.zip\n",
+        "!rm -rf uvr5_weights.zip\n",
+        "!mv uvr5_weights/* tools/uvr5/uvr5_weights\n",
+        "!rm -rf uvr5_weights"
       ]
     },
     {

--- a/docs/cn/Changelog_CN.md
+++ b/docs/cn/Changelog_CN.md
@@ -1,12 +1,12 @@
 ### 20240121更新
 
-1-config添加is_share，诸如colab等场景可以将此改为True，来使得webui映射到公网
+1-config添加is_share, 诸如colab等场景可以将此改为True, 来使得webui映射到公网
 
 2-WebUI添加英文系统英文翻译适配
 
-3-cmd-asr自动判断是否已自带damo模型，如不在默认目录上将从modelscope自带下载
+3-cmd-asr自动判断是否已自带damo模型, 如不在默认目录上将从modelscope自带下载
 
-4-[SoVITS训练报错ZeroDivisionError](https://github.com/RVC-Boss/GPT-SoVITS/issues/79) 尝试修复（过滤长度0的样本等）
+4-[SoVITS训练报错ZeroDivisionError](https://github.com/RVC-Boss/GPT-SoVITS/issues/79) 尝试修复(过滤长度0的样本等)
 
 5-清理TEMP文件夹缓存音频等文件
 
@@ -14,11 +14,11 @@
 
 ### 20240122更新
 
-1-修复过短输出文件返回重复参考音频的问题。
+1-修复过短输出文件返回重复参考音频的问题.
 
-2-经测试，英文日文训练原生支持（日文训练需要根目录不含非英文等特殊字符）。
+2-经测试, 英文日文训练原生支持(日文训练需要根目录不含非英文等特殊字符).
 
-3-音频路径检查。如果尝试读取输入错的路径报错路径不存在，而非ffmpeg错误。
+3-音频路径检查.如果尝试读取输入错的路径报错路径不存在, 而非ffmpeg错误.
 
 ### 20240123更新
 
@@ -44,7 +44,7 @@
 
 6-支持mac训练推理
 
-7-自动识别不支持半精度的卡强制单精度。cpu推理下强制单精度。
+7-自动识别不支持半精度的卡强制单精度.cpu推理下强制单精度.
 
 ### 20240128更新
 
@@ -85,7 +85,7 @@
 
 1-修复asr路径尾缀带/保存文件名报错
 
-2-引入paddlespeech的Normalizer https://github.com/RVC-Boss/GPT-SoVITS/pull/377 修复一些问题，例如：xx.xx%(带百分号类)，元/吨 会读成 元吨 而不是元每吨,下划线不再会报错
+2-引入paddlespeech的Normalizer https://github.com/RVC-Boss/GPT-SoVITS/pull/377 修复一些问题, 例如: xx.xx%(带百分号类), 元/吨 会读成 元吨 而不是元每吨,下划线不再会报错
 
 ### 20240207更新
 
@@ -93,7 +93,7 @@
 
 2-uvr5适配高版本librosa https://github.com/RVC-Boss/GPT-SoVITS/pull/403
 
-3-[修复uvr5 inf everywhere报错的问题(is_half传参未转换bool导致恒定半精度推理，16系显卡会inf)](https://github.com/RVC-Boss/GPT-SoVITS/commit/14a285109a521679f8846589c22da8f656a46ad8)
+3-[修复uvr5 inf everywhere报错的问题(is_half传参未转换bool导致恒定半精度推理, 16系显卡会inf)](https://github.com/RVC-Boss/GPT-SoVITS/commit/14a285109a521679f8846589c22da8f656a46ad8)
 
 4-优化英文文本前端
 
@@ -105,19 +105,19 @@
 
 ### 20240208更新
 
-1-GPT训练卡死（win10 1909）和https://github.com/RVC-Boss/GPT-SoVITS/issues/232 （系统语言繁体）GPT训练报错，[尝试修复](https://github.com/RVC-Boss/GPT-SoVITS/commit/59f35adad85815df27e9c6b33d420f5ebfd8376b)。
+1-GPT训练卡死 (win10 1909) 和https://github.com/RVC-Boss/GPT-SoVITS/issues/232 (系统语言繁体) GPT训练报错, [尝试修复](https://github.com/RVC-Boss/GPT-SoVITS/commit/59f35adad85815df27e9c6b33d420f5ebfd8376b).
 
 ### 20240212更新
 
-1-faster whisper和funasr逻辑优化。faster whisper转镜像站下载，规避huggingface连不上的问题。
+1-faster whisper和funasr逻辑优化.faster whisper转镜像站下载, 规避huggingface连不上的问题.
 
-2-DPO Loss实验性训练选项开启，通过构造负样本训练缓解GPT重复漏字问题。推理界面公开几个推理参数。 https://github.com/RVC-Boss/GPT-SoVITS/pull/457
+2-DPO Loss实验性训练选项开启, 通过构造负样本训练缓解GPT重复漏字问题.推理界面公开几个推理参数. https://github.com/RVC-Boss/GPT-SoVITS/pull/457
 
 ### 20240214更新
 
-1-训练支持中文实验名（原来会报错）
+1-训练支持中文实验名 (原来会报错)
 
-2-DPO训练改为可勾选选项而非必须。如勾选batch size自动减半。修复推理界面新参数不传参的问题。
+2-DPO训练改为可勾选选项而非必须.如勾选batch size自动减半.修复推理界面新参数不传参的问题.
 
 ### 20240216更新
 
@@ -127,7 +127,7 @@
 
 ### 20240221更新
 
-1-数据处理添加语音降噪选项（降噪为只剩16k采样率，除非底噪很大先不急着用哦。）
+1-数据处理添加语音降噪选项 (降噪为只剩16k采样率, 除非底噪很大先不急着用哦).
 
 2-中文日文前端处理优化 https://github.com/RVC-Boss/GPT-SoVITS/pull/559 https://github.com/RVC-Boss/GPT-SoVITS/pull/556 https://github.com/RVC-Boss/GPT-SoVITS/pull/532 https://github.com/RVC-Boss/GPT-SoVITS/pull/507 https://github.com/RVC-Boss/GPT-SoVITS/pull/509
 
@@ -137,7 +137,7 @@
 
 ### 20240306更新
 
-1-推理加速50%（RTX3090+pytorch2.2.1+cu11.8+win10+py39 tested）https://github.com/RVC-Boss/GPT-SoVITS/pull/672
+1-推理加速50% (RTX3090+pytorch2.2.1+cu11.8+win10+py39 tested) https://github.com/RVC-Boss/GPT-SoVITS/pull/672
 
 2-如果用faster whisper非中文ASR不再需要先下中文funasr模型
 
@@ -151,7 +151,7 @@
 
 2个重点
 
-1-修复sovits训练未冻结vq的问题（可能造成效果下降）
+1-修复sovits训练未冻结vq的问题 (可能造成效果下降)
 
 2-增加一个快速推理分支
 
@@ -171,21 +171,21 @@
 
 ### 20240610
 
-小问题修复：
+小问题修复: 
 
 1-完善纯标点、多标点文本输入的判断逻辑 https://github.com/RVC-Boss/GPT-SoVITS/pull/1168 https://github.com/RVC-Boss/GPT-SoVITS/pull/1169
 
-2-uvr5中的mdxnet去混响cmd格式修复，兼容路径带空格  [#501a74a](https://github.com/RVC-Boss/GPT-SoVITS/commit/501a74ae96789a26b48932babed5eb4e9483a232)
+2-uvr5中的mdxnet去混响cmd格式修复, 兼容路径带空格  [#501a74a](https://github.com/RVC-Boss/GPT-SoVITS/commit/501a74ae96789a26b48932babed5eb4e9483a232)
 
 3-s2训练进度条逻辑修复 https://github.com/RVC-Boss/GPT-SoVITS/pull/1159
 
-大问题修复：
+大问题修复: 
 
-4-修复了webui的GPT中文微调没读到bert导致和推理不一致，训练太多可能效果还会变差的问题。如果大量数据微调的建议重新微调模型得到质量优化 [#99f09c8](https://github.com/RVC-Boss/GPT-SoVITS/commit/99f09c8bdc155c1f4272b511940717705509582a)
+4-修复了webui的GPT中文微调没读到bert导致和推理不一致, 训练太多可能效果还会变差的问题.如果大量数据微调的建议重新微调模型得到质量优化 [#99f09c8](https://github.com/RVC-Boss/GPT-SoVITS/commit/99f09c8bdc155c1f4272b511940717705509582a)
 
 ### 20240706
 
-小问题修复：
+小问题修复: 
 
 1-[修正CPU推理默认bs小数](https://github.com/RVC-Boss/GPT-SoVITS/commit/db50670598f0236613eefa6f2d5a23a271d82041)
 
@@ -197,9 +197,9 @@
 
 5-移除冗余my_utils https://github.com/RVC-Boss/GPT-SoVITS/pull/1251
 
-重点：
+重点: 
 
-6-倍速推理代码经过验证后推理效果和base完全一致，合并进main。使用的代码：https://github.com/RVC-Boss/GPT-SoVITS/pull/672 。支持无参考文本模式也倍速。
+6-倍速推理代码经过验证后推理效果和base完全一致, 合并进main.使用的代码: https://github.com/RVC-Boss/GPT-SoVITS/pull/672 .支持无参考文本模式也倍速.
 
 后面会逐渐验证快速推理分支的推理改动的一致性
 
@@ -211,20 +211,20 @@
 
 3-修复GPT训练的step计算逻辑 https://github.com/RVC-Boss/GPT-SoVITS/pull/756
 
-重点：
+重点: 
 
-4-[支持合成语速调节。支持冻结随机性只调节语速，](https://github.com/RVC-Boss/GPT-SoVITS/commit/9588a3c52d9ebdb20b3c5d74f647d12e7c1171c2)并将其更新到api.py上https://github.com/RVC-Boss/GPT-SoVITS/pull/1340
+4-[支持合成语速调节.支持冻结随机性只调节语速, ](https://github.com/RVC-Boss/GPT-SoVITS/commit/9588a3c52d9ebdb20b3c5d74f647d12e7c1171c2)并将其更新到api.py上https://github.com/RVC-Boss/GPT-SoVITS/pull/1340
 
 
 ### 20240806
 
-1-增加bs-roformer人声伴奏分离模型支持。 https://github.com/RVC-Boss/GPT-SoVITS/pull/1306 https://github.com/RVC-Boss/GPT-SoVITS/pull/1356 [支持fp16推理。](https://github.com/RVC-Boss/GPT-SoVITS/commit/e62e965323a60a76a025bcaa45268c1ddcbcf05c)
+1-增加bs-roformer人声伴奏分离模型支持. https://github.com/RVC-Boss/GPT-SoVITS/pull/1306 https://github.com/RVC-Boss/GPT-SoVITS/pull/1356 [支持fp16推理.](https://github.com/RVC-Boss/GPT-SoVITS/commit/e62e965323a60a76a025bcaa45268c1ddcbcf05c)
 
-2-更好的中文文本前端。 https://github.com/RVC-Boss/GPT-SoVITS/pull/987 https://github.com/RVC-Boss/GPT-SoVITS/pull/1351 https://github.com/RVC-Boss/GPT-SoVITS/pull/1404 优化多音字逻辑（v2版本特供）。 https://github.com/RVC-Boss/GPT-SoVITS/pull/488
+2-更好的中文文本前端. https://github.com/RVC-Boss/GPT-SoVITS/pull/987 https://github.com/RVC-Boss/GPT-SoVITS/pull/1351 https://github.com/RVC-Boss/GPT-SoVITS/pull/1404 优化多音字逻辑 (v2版本特供). https://github.com/RVC-Boss/GPT-SoVITS/pull/488
 
 3-自动填充下一步的文件路径 https://github.com/RVC-Boss/GPT-SoVITS/pull/1355
 
-4-增加喂饭逻辑，用户瞎写显卡序号也可以正常运作 [bce451a](https://github.com/RVC-Boss/GPT-SoVITS/commit/bce451a2d1641e581e200297d01f219aeaaf7299) [4c8b761](https://github.com/RVC-Boss/GPT-SoVITS/commit/4c8b7612206536b8b4435997acb69b25d93acb78)
+4-增加喂饭逻辑, 用户瞎写显卡序号也可以正常运作 [bce451a](https://github.com/RVC-Boss/GPT-SoVITS/commit/bce451a2d1641e581e200297d01f219aeaaf7299) [4c8b761](https://github.com/RVC-Boss/GPT-SoVITS/commit/4c8b7612206536b8b4435997acb69b25d93acb78)
 
 5-增加粤语ASR支持 [8a10147](https://github.com/RVC-Boss/GPT-SoVITS/commit/8a101474b5a4f913b4c94fca2e3ca87d0771bae3)
 
@@ -234,11 +234,11 @@
 
 ### 20240821
 
-1-fast_inference分支合并进main：https://github.com/RVC-Boss/GPT-SoVITS/pull/1490
+1-fast_inference分支合并进main: https://github.com/RVC-Boss/GPT-SoVITS/pull/1490
 
-2-支持通过ssml标签优化数字、电话、时间日期等：https://github.com/RVC-Boss/GPT-SoVITS/issues/1508
+2-支持通过ssml标签优化数字、电话、时间日期等: https://github.com/RVC-Boss/GPT-SoVITS/issues/1508
 
-3-api修复优化：https://github.com/RVC-Boss/GPT-SoVITS/pull/1503
+3-api修复优化: https://github.com/RVC-Boss/GPT-SoVITS/pull/1503
 
 4-修复了参考音频混合只能上传一条的bug:https://github.com/RVC-Boss/GPT-SoVITS/pull/1422
 
@@ -246,11 +246,11 @@
 
 ### 20250211
 
-增加gpt-sovits-v3模型，需要14G显存可以微调
+增加gpt-sovits-v3模型, 需要14G显存可以微调
 
 ### 20250212
 
-sovits-v3微调支持开启梯度检查点，需要12G显存可以微调https://github.com/RVC-Boss/GPT-SoVITS/pull/2040
+sovits-v3微调支持开启梯度检查点, 需要12G显存可以微调https://github.com/RVC-Boss/GPT-SoVITS/pull/2040
 
 ### 20250214
 
@@ -266,7 +266,7 @@ sovits-v3微调支持开启梯度检查点，需要12G显存可以微调https://
 
 ### 20250223
 
-1-sovits-v3微调支持lora训练，需要8G显存可以微调，效果比全参微调更好
+1-sovits-v3微调支持lora训练, 需要8G显存可以微调, 效果比全参微调更好
 
 2-人声背景音分离增加mel band roformer模型支持https://github.com/RVC-Boss/GPT-SoVITS/pull/2078
 
@@ -274,11 +274,11 @@ sovits-v3微调支持开启梯度检查点，需要12G显存可以微调https://
 
 https://github.com/RVC-Boss/GPT-SoVITS/pull/2112 https://github.com/RVC-Boss/GPT-SoVITS/pull/2114
 
-修复中文路径下mecab的报错（具体表现为日文韩文、文本混合语种切分可能会遇到的报错）
+修复中文路径下mecab的报错 (具体表现为日文韩文、文本混合语种切分可能会遇到的报错)
 
 ### 20250227
 
-针对v3生成24k音频感觉闷的问题https://github.com/RVC-Boss/GPT-SoVITS/issues/2085 https://github.com/RVC-Boss/GPT-SoVITS/issues/2117 ,支持使用24k to 48k的音频超分模型缓解。
+针对v3生成24k音频感觉闷的问题https://github.com/RVC-Boss/GPT-SoVITS/issues/2085 https://github.com/RVC-Boss/GPT-SoVITS/issues/2117 ,支持使用24k to 48k的音频超分模型缓解.
 
 
 ### 20250228
@@ -295,8 +295,8 @@ https://github.com/RVC-Boss/GPT-SoVITS/pull/2112 https://github.com/RVC-Boss/GPT
 
 修复其他若干bug
 
-重点更新：
+重点更新: 
 
 1-v3支持并行推理 https://github.com/RVC-Boss/GPT-SoVITS/commit/03b662a769946b7a6a8569a354860e8eeeb743aa
 
-2-整合包修复onnxruntime GPU推理的支持，影响：（1）g2pw有个onnx模型原先是CPU推理现在用GPU，显著降低推理的CPU瓶颈 （2）foxjoy去混响模型现在可使用GPU推理
+2-整合包修复onnxruntime GPU推理的支持, 影响:  (1) g2pw有个onnx模型原先是CPU推理现在用GPU, 显著降低推理的CPU瓶颈 (2) foxjoy去混响模型现在可使用GPU推理

--- a/docs/cn/README.md
+++ b/docs/cn/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 
 <h1>GPT-SoVITS-WebUI</h1>
-强大的少样本语音转换与语音合成Web用户界面。<br><br>
+强大的少样本语音转换与语音合成Web用户界面.<br><br>
 
 [![madewithlove](https://img.shields.io/badge/made_with-%E2%9D%A4-red?style=for-the-badge&labelColor=orange)](https://github.com/RVC-Boss/GPT-SoVITS)
 
@@ -20,19 +20,19 @@
 
 ---
 
-## 功能：
+## 功能: 
 
-1. **零样本文本到语音（TTS）：** 输入 5 秒的声音样本，即刻体验文本到语音转换。
+1. **零样本文本到语音 (TTS): ** 输入 5 秒的声音样本, 即刻体验文本到语音转换.
 
-2. **少样本 TTS：** 仅需 1 分钟的训练数据即可微调模型，提升声音相似度和真实感。
+2. **少样本 TTS: ** 仅需 1 分钟的训练数据即可微调模型, 提升声音相似度和真实感.
 
-3. **跨语言支持：** 支持与训练数据集不同语言的推理，目前支持英语、日语、韩语、粤语和中文。
+3. **跨语言支持: ** 支持与训练数据集不同语言的推理, 目前支持英语、日语、韩语、粤语和中文.
 
-4. **WebUI 工具：** 集成工具包括声音伴奏分离、自动训练集分割、中文自动语音识别(ASR)和文本标注，协助初学者创建训练数据集和 GPT/SoVITS 模型。
+4. **WebUI 工具: ** 集成工具包括声音伴奏分离、自动训练集分割、中文自动语音识别(ASR)和文本标注, 协助初学者创建训练数据集和 GPT/SoVITS 模型.
 
 **查看我们的介绍视频 [demo video](https://www.bilibili.com/video/BV12g4y1m7Uw)**
 
-未见过的说话者 few-shot 微调演示：
+未见过的说话者 few-shot 微调演示: 
 
 https://github.com/RVC-Boss/GPT-SoVITS/assets/129054828/05bee1fa-bdd8-4d85-9350-80c060ab47fb
 
@@ -40,22 +40,24 @@ https://github.com/RVC-Boss/GPT-SoVITS/assets/129054828/05bee1fa-bdd8-4d85-9350-
 
 ## 安装
 
-中国地区的用户可[点击此处](https://www.codewithgpu.com/i/RVC-Boss/GPT-SoVITS/GPT-SoVITS-Official)使用 AutoDL 云端镜像进行体验。
+中国地区的用户可[点击此处](https://www.codewithgpu.com/i/RVC-Boss/GPT-SoVITS/GPT-SoVITS-Official)使用 AutoDL 云端镜像进行体验.
 
 ### 测试通过的环境
 
-- Python 3.9，PyTorch 2.0.1，CUDA 11
-- Python 3.10.13，PyTorch 2.1.2，CUDA 12.3
-- Python 3.9，Pytorch 2.2.2，macOS 14.4.1（Apple 芯片）
-- Python 3.9，PyTorch 2.2.2，CPU 设备
-
-_注: numba==0.56.4 需要 python<3.11_
+| Python Version | PyTorch Version  | Device          |
+|----------------|------------------|-----------------|
+| Python 3.9     | PyTorch 2.0.1    | CUDA 11.8       |
+| Python 3.10.13 | PyTorch 2.1.2    | CUDA 12.3       |
+| Python 3.10.17 | PyTorch 2.5.1    | CUDA 12.4       |
+| Python 3.9     | PyTorch 2.5.1    | Apple silicon   |
+| Python 3.11    | PyTorch 2.6.0    | Apple silicon   |
+| Python 3.9     | PyTorch 2.2.2    | CPU             |
 
 ### Windows
 
-如果你是 Windows 用户（已在 win>=10 上测试），可以下载[整合包](https://huggingface.co/lj1995/GPT-SoVITS-windows-package/resolve/main/GPT-SoVITS-v3lora-20250228.7z?download=true)，解压后双击 go-webui.bat 即可启动 GPT-SoVITS-WebUI。
+如果你是 Windows 用户 (已在 win>=10 上测试), 可以下载[整合包](https://huggingface.co/lj1995/GPT-SoVITS-windows-package/resolve/main/GPT-SoVITS-v3lora-20250228.7z?download=true), 解压后双击 go-webui.bat 即可启动 GPT-SoVITS-WebUI.
 
-**中国地区的用户可以[在此处下载整合包](https://www.yuque.com/baicaigongchang1145haoyuangong/ib3g1e/dkxgpiy9zb96hob4#KTvnO)。**
+**中国地区的用户可以[在此处下载整合包](https://www.yuque.com/baicaigongchang1145haoyuangong/ib3g1e/dkxgpiy9zb96hob4#KTvnO).**
 
 ### Linux
 
@@ -67,11 +69,11 @@ bash install.sh
 
 ### macOS
 
-**注：在 Mac 上使用 GPU 训练的模型效果显著低于其他设备训练的模型，所以我们暂时使用 CPU 进行训练。**
+**注: 在 Mac 上使用 GPU 训练的模型效果显著低于其他设备训练的模型, 所以我们暂时使用 CPU 进行训练.**
 
-1. 运行 `xcode-select --install` 安装 Xcode command-line tools。
-2. 运行 `brew install ffmpeg` 安装 FFmpeg。
-3. 完成上述步骤后，运行以下的命令来安装本项目：
+1. 运行 `xcode-select --install` 安装 Xcode command-line tools.
+2. 运行 `brew install ffmpeg` 安装 FFmpeg.
+3. 完成上述步骤后, 运行以下的命令来安装本项目: 
 
 ```bash
 conda create -n GPTSoVits python=3.9
@@ -100,7 +102,7 @@ conda install -c conda-forge 'ffmpeg<7'
 
 ##### Windows 用户
 
-下载并将 [ffmpeg.exe](https://huggingface.co/lj1995/VoiceConversionWebUI/blob/main/ffmpeg.exe) 和 [ffprobe.exe](https://huggingface.co/lj1995/VoiceConversionWebUI/blob/main/ffprobe.exe) 放置在 GPT-SoVITS 根目录下。
+下载并将 [ffmpeg.exe](https://huggingface.co/lj1995/VoiceConversionWebUI/blob/main/ffmpeg.exe) 和 [ffprobe.exe](https://huggingface.co/lj1995/VoiceConversionWebUI/blob/main/ffprobe.exe) 放置在 GPT-SoVITS 根目录下.
 
 安装 [Visual Studio 2017](https://aka.ms/vs/17/release/vc_redist.x86.exe) 环境(仅限韩语 TTS)
 
@@ -121,14 +123,14 @@ pip install -r requirements.txt
 
 #### docker-compose.yaml 设置
 
-0. image 的标签：由于代码库更新很快，镜像的打包和测试又很慢，所以请自行在 [Docker Hub](https://hub.docker.com/r/breakstring/gpt-sovits) 查看当前打包好的最新的镜像并根据自己的情况选用，或者在本地根据您自己的需求通过 Dockerfile 进行构建。
-1. 环境变量：
+0. image 的标签: 由于代码库更新很快, 镜像的打包和测试又很慢, 所以请自行在 [Docker Hub](https://hub.docker.com/r/breakstring/gpt-sovits)(旧版本) 查看当前打包好的最新的镜像并根据自己的情况选用, 或者在本地根据您自己的需求通过 Dockerfile 进行构建.
+1. 环境变量: 
 
-- is_half: 半精度/双精度控制。在进行 "SSL extracting" 步骤时如果无法正确生成 4-cnhubert/5-wav32k 目录下的内容时，一般都是它引起的，可以根据实际情况来调整为 True 或者 False。
+- is_half: 半精度/双精度控制.在进行 "SSL extracting" 步骤时如果无法正确生成 4-cnhubert/5-wav32k 目录下的内容时, 一般都是它引起的, 可以根据实际情况来调整为 True 或者 False.
 
-2. Volume 设置，容器内的应用根目录设置为 /workspace。 默认的 docker-compose.yaml 中列出了一些实际的例子，便于上传/下载内容。
-3. shm_size：Windows 下的 Docker Desktop 默认可用内存过小，会导致运行异常，根据自己情况酌情设置。
-4. deploy 小节下的 gpu 相关内容，请根据您的系统和实际情况酌情设置。
+2. Volume 设置, 容器内的应用根目录设置为 /workspace. 默认的 docker-compose.yaml 中列出了一些实际的例子, 便于上传/下载内容.
+3. shm_size: Windows 下的 Docker Desktop 默认可用内存过小, 会导致运行异常, 根据自己情况酌情设置.
+4. deploy 小节下的 gpu 相关内容, 请根据您的系统和实际情况酌情设置.
 
 #### 通过 docker compose 运行
 
@@ -138,7 +140,7 @@ docker compose -f "docker-compose.yaml" up -d
 
 #### 通过 docker 命令运行
 
-同上，根据您自己的实际情况修改对应的参数，然后运行如下命令：
+同上, 根据您自己的实际情况修改对应的参数, 然后运行如下命令: 
 
 ```
 docker run --rm -it --gpus=all --env=is_half=False --volume=G:\GPT-SoVITS-DockerTest\output:/workspace/output --volume=G:\GPT-SoVITS-DockerTest\logs:/workspace/logs --volume=G:\GPT-SoVITS-DockerTest\SoVITS_weights:/workspace/SoVITS_weights --workdir=/workspace -p 9880:9880 -p 9871:9871 -p 9872:9872 -p 9873:9873 -p 9874:9874 --shm-size="16G" -d breakstring/gpt-sovits:xxxxx
@@ -146,31 +148,33 @@ docker run --rm -it --gpus=all --env=is_half=False --volume=G:\GPT-SoVITS-Docker
 
 ## 预训练模型
 
-**中国地区的用户可以[在此处下载这些模型](https://www.yuque.com/baicaigongchang1145haoyuangong/ib3g1e/dkxgpiy9zb96hob4#nVNhX)。**
+**若成功运行`install.sh`可跳过 No.1**
 
-1. 从 [GPT-SoVITS Models](https://huggingface.co/lj1995/GPT-SoVITS) 下载预训练模型，并将其放置在 `GPT_SoVITS/pretrained_models` 目录中。
+**中国地区的用户可以[在此处下载这些模型](https://www.yuque.com/baicaigongchang1145haoyuangong/ib3g1e/dkxgpiy9zb96hob4#nVNhX).**
 
-2. 从 [G2PWModel_1.1.zip](https://paddlespeech.cdn.bcebos.com/Parakeet/released_models/g2p/G2PWModel_1.1.zip) 下载模型，解压并重命名为 `G2PWModel`，然后将其放置在 `GPT_SoVITS/text` 目录中。（仅限中文 TTS）
+1. 从 [GPT-SoVITS Models](https://huggingface.co/lj1995/GPT-SoVITS) 下载预训练模型, 并将其放置在 `GPT_SoVITS/pretrained_models` 目录中.
 
-3. 对于 UVR5（人声/伴奏分离和混响移除，额外功能），从 [UVR5 Weights](https://huggingface.co/lj1995/VoiceConversionWebUI/tree/main/uvr5_weights) 下载模型，并将其放置在 `tools/uvr5/uvr5_weights` 目录中。
+2. 从 [G2PWModel_1.1.zip](https://paddlespeech.cdn.bcebos.com/Parakeet/released_models/g2p/G2PWModel_1.1.zip) 下载模型, 解压并重命名为 `G2PWModel`, 然后将其放置在 `GPT_SoVITS/text` 目录中. (仅限中文 TTS)
 
-   - 如果你在 UVR5 中使用 `bs_roformer` 或 `mel_band_roformer`模型，你可以手动下载模型和相应的配置文件，并将它们放在 `tools/UVR5/UVR5_weights` 中。**重命名模型文件和配置文件，确保除后缀外**，模型和配置文件具有相同且对应的名称。此外，模型和配置文件名**必须包含“roformer”**，才能被识别为 roformer 类的模型。
+3. 对于 UVR5 (人声/伴奏分离和混响移除, 额外功能), 从 [UVR5 Weights](https://huggingface.co/lj1995/VoiceConversionWebUI/tree/main/uvr5_weights) 下载模型, 并将其放置在 `tools/uvr5/uvr5_weights` 目录中.
 
-   - 建议在模型名称和配置文件名中**直接指定模型类型**，例如`mel_mand_roformer`、`bs_roformer`。如果未指定，将从配置文中比对特征，以确定它是哪种类型的模型。例如，模型`bs_roformer_ep_368_sdr_12.9628.ckpt` 和对应的配置文件`bs_roformer_ep_368_sdr_12.9628.yaml` 是一对。`kim_mel_band_roformer.ckpt` 和 `kim_mel_band_roformer.yaml` 也是一对。
+   - 如果你在 UVR5 中使用 `bs_roformer` 或 `mel_band_roformer`模型, 你可以手动下载模型和相应的配置文件, 并将它们放在 `tools/UVR5/UVR5_weights` 中.**重命名模型文件和配置文件, 确保除后缀外**, 模型和配置文件具有相同且对应的名称.此外, 模型和配置文件名**必须包含"roformer"**, 才能被识别为 roformer 类的模型.
 
-4. 对于中文 ASR（额外功能），从 [Damo ASR Model](https://modelscope.cn/models/damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch/files)、[Damo VAD Model](https://modelscope.cn/models/damo/speech_fsmn_vad_zh-cn-16k-common-pytorch/files) 和 [Damo Punc Model](https://modelscope.cn/models/damo/punc_ct-transformer_zh-cn-common-vocab272727-pytorch/files) 下载模型，并将它们放置在 `tools/asr/models` 目录中。
+   - 建议在模型名称和配置文件名中**直接指定模型类型**, 例如`mel_mand_roformer`、`bs_roformer`.如果未指定, 将从配置文中比对特征, 以确定它是哪种类型的模型.例如, 模型`bs_roformer_ep_368_sdr_12.9628.ckpt` 和对应的配置文件`bs_roformer_ep_368_sdr_12.9628.yaml` 是一对.`kim_mel_band_roformer.ckpt` 和 `kim_mel_band_roformer.yaml` 也是一对.
 
-5. 对于英语或日语 ASR（额外功能），从 [Faster Whisper Large V3](https://huggingface.co/Systran/faster-whisper-large-v3) 下载模型，并将其放置在 `tools/asr/models` 目录中。此外，[其他模型](https://huggingface.co/Systran) 可能具有类似效果且占用更少的磁盘空间。
+4. 对于中文 ASR (额外功能), 从 [Damo ASR Model](https://modelscope.cn/models/damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch/files)、[Damo VAD Model](https://modelscope.cn/models/damo/speech_fsmn_vad_zh-cn-16k-common-pytorch/files) 和 [Damo Punc Model](https://modelscope.cn/models/damo/punc_ct-transformer_zh-cn-common-vocab272727-pytorch/files) 下载模型, 并将它们放置在 `tools/asr/models` 目录中.
+
+5. 对于英语或日语 ASR (额外功能), 从 [Faster Whisper Large V3](https://huggingface.co/Systran/faster-whisper-large-v3) 下载模型, 并将其放置在 `tools/asr/models` 目录中.此外, [其他模型](https://huggingface.co/Systran) 可能具有类似效果且占用更少的磁盘空间.
 
 ## 数据集格式
 
-文本到语音（TTS）注释 .list 文件格式：
+文本到语音 (TTS) 注释 .list 文件格式: 
 
 ```
 vocal_path|speaker_name|language|text
 ```
 
-语言字典：
+语言字典: 
 
 - 'zh': 中文
 - 'ja': 日语
@@ -178,10 +182,10 @@ vocal_path|speaker_name|language|text
 - 'ko': 韩语
 - 'yue': 粤语
 
-示例：
+示例: 
 
 ```
-D:\GPT-SoVITS\xxx/xxx.wav|xxx|zh|我爱玩原神。
+D:\GPT-SoVITS\xxx/xxx.wav|xxx|zh|我爱玩原神.
 ```
 
 ## 微调与推理
@@ -248,7 +252,7 @@ python webui.py
 
 3. 底模由 2k 小时扩展至 5k 小时
 
-4. 对低音质参考音频（尤其是来源于网络的高频严重缺失、听着很闷的音频）合成出来音质更好
+4. 对低音质参考音频 (尤其是来源于网络的高频严重缺失、听着很闷的音频) 合成出来音质更好
 
    详见[wiki](<https://github.com/RVC-Boss/GPT-SoVITS/wiki/GPT%E2%80%90SoVITS%E2%80%90v2%E2%80%90features-(%E6%96%B0%E7%89%B9%E6%80%A7)>)
 
@@ -260,15 +264,15 @@ python webui.py
 
 3. 需要从[huggingface](https://huggingface.co/lj1995/GPT-SoVITS/tree/main/gsv-v2final-pretrained) 下载预训练模型文件放到 GPT_SoVITS\pretrained_models\gsv-v2final-pretrained 下
 
-   中文额外需要下载[G2PWModel_1.1.zip](https://paddlespeech.cdn.bcebos.com/Parakeet/released_models/g2p/G2PWModel_1.1.zip)（下载 G2PW 模型,解压并重命名为`G2PWModel`,将其放到`GPT_SoVITS/text`目录下）
+   中文额外需要下载[G2PWModel_1.1.zip](https://paddlespeech.cdn.bcebos.com/Parakeet/released_models/g2p/G2PWModel_1.1.zip) (下载 G2PW 模型,解压并重命名为`G2PWModel`,将其放到`GPT_SoVITS/text`目录下)
 
 ## V3 更新说明
 
 新模型特点:
 
-1. 音色相似度更像，需要更少训练集来逼近本人（不训练直接使用底模模式下音色相似性提升更大）
+1. 音色相似度更像, 需要更少训练集来逼近本人 (不训练直接使用底模模式下音色相似性提升更大)
 
-2. GPT 合成更稳定，重复漏字更少，也更容易跑出丰富情感
+2. GPT 合成更稳定, 重复漏字更少, 也更容易跑出丰富情感
 
    详见[wiki](<https://github.com/RVC-Boss/GPT-SoVITS/wiki/GPT%E2%80%90SoVITS%E2%80%90v2%E2%80%90features-(%E6%96%B0%E7%89%B9%E6%80%A7)>)
 
@@ -280,29 +284,29 @@ python webui.py
 
 3. 从[huggingface](https://huggingface.co/lj1995/GPT-SoVITS/tree/main)下载这些 v3 新增预训练模型 (s1v3.ckpt, s2Gv3.pth and models--nvidia--bigvgan_v2_24khz_100band_256x folder)将他们放到`GPT_SoVITS\pretrained_models`目录下
 
-   如果想用音频超分功能缓解 v3 模型生成 24k 音频觉得闷的问题，需要下载额外的模型参数，参考[how to download](../../tools/AP_BWE_main/24kto48k/readme.txt)
+   如果想用音频超分功能缓解 v3 模型生成 24k 音频觉得闷的问题, 需要下载额外的模型参数, 参考[how to download](../../tools/AP_BWE_main/24kto48k/readme.txt)
 
 ## 待办事项清单
 
-- [x] **高优先级：**
+- [x] **高优先级: **
 
-  - [x] 日语和英语的本地化。
-  - [x] 用户指南。
-  - [x] 日语和英语数据集微调训练。
+  - [x] 日语和英语的本地化.
+  - [x] 用户指南.
+  - [x] 日语和英语数据集微调训练.
 
 - [ ] **功能:**
-  - [x] 零样本声音转换（5 秒）/ 少样本声音转换（1 分钟）。
-  - [x] TTS 语速控制。
-  - [ ] ~~增强的 TTS 情感控制。~~
-  - [ ] 尝试将 SoVITS 令牌输入更改为词汇的概率分布。
-  - [x] 改进英语和日语文本前端。
-  - [ ] 开发体积小和更大的 TTS 模型。
-  - [x] Colab 脚本。
-  - [x] 扩展训练数据集（从 2k 小时到 10k 小时）。
-  - [x] 更好的 sovits 基础模型（增强的音频质量）。
-  - [ ] 模型混合。
+  - [x] 零样本声音转换 (5 秒) / 少样本声音转换 (1 分钟).
+  - [x] TTS 语速控制.
+  - [ ] ~~增强的 TTS 情感控制.~~
+  - [ ] 尝试将 SoVITS 令牌输入更改为词汇的概率分布.
+  - [x] 改进英语和日语文本前端.
+  - [ ] 开发体积小和更大的 TTS 模型.
+  - [x] Colab 脚本.
+  - [x] 扩展训练数据集 (从 2k 小时到 10k 小时).
+  - [x] 更好的 sovits 基础模型 (增强的音频质量).
+  - [ ] 模型混合.
 
-## （附加）命令行运行方式
+##  (附加) 命令行运行方式
 
 使用命令行打开 UVR5 的 WebUI
 
@@ -310,7 +314,7 @@ python webui.py
 python tools/uvr5/webui.py "<infer_device>" <is_half> <webui_port_uvr5>
 ```
 
-<!-- 如果打不开浏览器，请按照下面的格式进行UVR处理，这是使用mdxnet进行音频处理的方式
+<!-- 如果打不开浏览器, 请按照下面的格式进行UVR处理, 这是使用mdxnet进行音频处理的方式
 ````
 python mdxnet.py --model --input_root --output_vocal --output_ins --agg_level --format --device --is_half_precision
 ```` -->
@@ -327,15 +331,15 @@ python audio_slicer.py \
     --hop_size <step_size_for_computing_volume_curve>
 ```
 
-这是使用命令行完成数据集 ASR 处理的方式（仅限中文）
+这是使用命令行完成数据集 ASR 处理的方式 (仅限中文)
 
 ```
 python tools/asr/funasr_asr.py -i <input> -o <output>
 ```
 
-通过 Faster_Whisper 进行 ASR 处理（除中文之外的 ASR 标记）
+通过 Faster_Whisper 进行 ASR 处理 (除中文之外的 ASR 标记)
 
-（没有进度条，GPU 性能可能会导致时间延迟）
+ (没有进度条, GPU 性能可能会导致时间延迟)
 
 ```
 python ./tools/asr/fasterwhisper_asr.py -i <input> -o <output> -l <language> -p <precision>
@@ -345,7 +349,7 @@ python ./tools/asr/fasterwhisper_asr.py -i <input> -o <output> -l <language> -p 
 
 ## 致谢
 
-特别感谢以下项目和贡献者：
+特别感谢以下项目和贡献者: 
 
 ### 理论研究
 
@@ -384,7 +388,7 @@ python ./tools/asr/fasterwhisper_asr.py -i <input> -o <output> -l <language> -p 
 - [FunASR](https://github.com/alibaba-damo-academy/FunASR)
 - [AP-BWE](https://github.com/yxlu-0102/AP-BWE)
 
-感谢 @Naozumi520 提供粤语训练集，并在粤语相关知识方面给予指导。
+感谢 @Naozumi520 提供粤语训练集, 并在粤语相关知识方面给予指导.
 
 ## 感谢所有贡献者的努力
 

--- a/docs/ja/Changelog_JA.md
+++ b/docs/ja/Changelog_JA.md
@@ -1,221 +1,221 @@
 ### 20240121 更新
 
-1. `config`に`is_share`を追加し、Colab などの環境でこれを`True`に設定すると、webui を公共ネットワークにマッピングできます。
-2. WebUI に英語システムの英語翻訳を追加しました。
-3. `cmd-asr`は FunASR モデルが既に含まれているかどうかを自動的に確認し、デフォルトのパスにない場合は modelscope から自動的にダウンロードします。
-4. [SoVITS 训练报错 ZeroDivisionError](https://github.com/RVC-Boss/GPT-SoVITS/issues/79) 修復を試みます（長さ 0 のサンプルをフィルタリングなど）
-5. TEMP ファイルフォルダからオーディオやその他のファイルをクリーンアップして最適化します。
-6. 合成オーディオがリファレンスオーディオの終わりを含む問題を大幅に改善しました。
+1. `config`に`is_share`を追加し、Colab などの環境でこれを`True`に設定すると、webui を公共ネットワークにマッピングできます.
+2. WebUI に英語システムの英語翻訳を追加しました.
+3. `cmd-asr`は FunASR モデルが既に含まれているかどうかを自動的に確認し、デフォルトのパスにない場合は modelscope から自動的にダウンロードします.
+4. [SoVITS 训练报错 ZeroDivisionError](https://github.com/RVC-Boss/GPT-SoVITS/issues/79) 修復を試みます (長さ 0 のサンプルをフィルタリングなど)
+5. TEMP ファイルフォルダからオーディオやその他のファイルをクリーンアップして最適化します.
+6. 合成オーディオがリファレンスオーディオの終わりを含む問題を大幅に改善しました.
 
 ### 20240122 更新
 
-1. 短すぎる出力ファイルが重複したリファレンスオーディオを返す問題を修正しました。
-2. 英語-日本語学習がスムーズに進む QA を完了しました。（ただし、日本語学習はルートディレクトリに英語以外の文字が含まれていない必要があります）
-3. オーディオパスをチェックします。間違ったパスを読み取ろうとすると、「パスが存在しません」というエラーメッセージが返されます。これは ffmpeg モジュールのエラーではありません。
+1. 短すぎる出力ファイルが重複したリファレンスオーディオを返す問題を修正しました.
+2. 英語-日本語学習がスムーズに進む QA を完了しました. (ただし、日本語学習はルートディレクトリに英語以外の文字が含まれていない必要があります)
+3. オーディオパスをチェックします.間違ったパスを読み取ろうとすると、「パスが存在しません」というエラーメッセージが返されます.これは ffmpeg モジュールのエラーではありません.
 
 ### 20240123 更新
 
-1. hubert から nan 抽出による SoVITS/GPT 学習中の ZeroDivisionError 関連エラーを修正しました。
-2. 推論インターフェースでモデルを素早く切り替えることができるようにサポートしました。
-3. モデルファイルのソートロジックを最適化しました。
-4. 中国語の分析に `jieba_fast` を `jieba` に置き換えました。
+1. hubert から nan 抽出による SoVITS/GPT 学習中の ZeroDivisionError 関連エラーを修正しました.
+2. 推論インターフェースでモデルを素早く切り替えることができるようにサポートしました.
+3. モデルファイルのソートロジックを最適化しました.
+4. 中国語の分析に `jieba_fast` を `jieba` に置き換えました.
 
 ### 20240126 更新
 
-1. 中国語と英語、日本語と英語が混在した出力テキストをサポートします。
-2. 出力で選択的な分割モードをサポートします。
-3. uvr5 がディレクトリを読み取り、自動的に終了する問題を修正しました。
-4. 複数の改行による推論エラーを修正しました。
-5. 推論インターフェースから不要なログを削除しました。
-6. MacOS での学習と推論をサポートします。
-7. 半精度をサポートしていないカードを自動的に識別して単精度を強制し、CPU 推論では単精度を強制します。
+1. 中国語と英語、日本語と英語が混在した出力テキストをサポートします.
+2. 出力で選択的な分割モードをサポートします.
+3. uvr5 がディレクトリを読み取り、自動的に終了する問題を修正しました.
+4. 複数の改行による推論エラーを修正しました.
+5. 推論インターフェースから不要なログを削除しました.
+6. MacOS での学習と推論をサポートします.
+7. 半精度をサポートしていないカードを自動的に識別して単精度を強制し、CPU 推論では単精度を強制します.
 
 ### 20240128 更新
 
-1. 数字を漢字で読む問題を修正しました。
-2. 文章の先頭の一部の単語が欠落する問題を修正しました。
-3. 不適切な長さのリファレンスオーディオを制限しました。
-4. GPT 学習時の ckpt が保存されない問題を修正しました。
-5. Dockerfile のモデルダウンロードプロセスを改善しました。
+1. 数字を漢字で読む問題を修正しました.
+2. 文章の先頭の一部の単語が欠落する問題を修正しました.
+3. 不適切な長さのリファレンスオーディオを制限しました.
+4. GPT 学習時の ckpt が保存されない問題を修正しました.
+5. Dockerfile のモデルダウンロードプロセスを改善しました.
 
 ### 20240129 更新
 
-1. 16 系などの半精度学習に問題があるカードは、学習構成を単精度学習に変更しました。
-2. Colab でも使用可能なバージョンをテストして更新しました。
-3. ModelScope FunASR リポジトリの古いバージョンで git クローンを行う際のインターフェース不整合エラーの問題を修正しました。
+1. 16 系などの半精度学習に問題があるカードは、学習構成を単精度学習に変更しました.
+2. Colab でも使用可能なバージョンをテストして更新しました.
+3. ModelScope FunASR リポジトリの古いバージョンで git クローンを行う際のインターフェース不整合エラーの問題を修正しました.
 
 ### 20240130 更新
 
-1. パスと関連する文字列を解析して、二重引用符を自動的に削除します。また、パスをコピーする場合、二重引用符が含まれていてもエラーが発生しません。
-2. 中国語と英語、日本語と英語の混合出力をサポートします。
-3. 出力で選択的な分割モードをサポートします。
+1. パスと関連する文字列を解析して、二重引用符を自動的に削除します.また、パスをコピーする場合、二重引用符が含まれていてもエラーが発生しません.
+2. 中国語と英語、日本語と英語の混合出力をサポートします.
+3. 出力で選択的な分割モードをサポートします.
 
 ### 20240201 更新
 
-1. UVR5 形式の読み取りエラーによる分離失敗を修正しました。
-2. 中国語・日本語・英語の混合テキストに対する自動分割と言語認識をサポートしました。
+1. UVR5 形式の読み取りエラーによる分離失敗を修正しました.
+2. 中国語・日本語・英語の混合テキストに対する自動分割と言語認識をサポートしました.
 
 ### 20240202 更新
 
-1. ASRパスが `/` で終わることによるファイル名保存エラーの問題を修正しました。
-2. [PR 377](https://github.com/RVC-Boss/GPT-SoVITS/pull/377) で PaddleSpeech の Normalizer を導入し、"xx.xx%"（パーセント記号）の読み取りや"元/吨"が"元吨"ではなく"元每吨"と読まれる問題、アンダースコアエラーを修正しました。
+1. ASRパスが `/` で終わることによるファイル名保存エラーの問題を修正しました.
+2. [PR 377](https://github.com/RVC-Boss/GPT-SoVITS/pull/377) で PaddleSpeech の Normalizer を導入し、"xx.xx%" (パーセント記号) の読み取りや"元/吨"が"元吨"ではなく"元每吨"と読まれる問題、アンダースコアエラーを修正しました.
 
 ### 20240207 更新
 
-1. [Issue 391](https://github.com/RVC-Boss/GPT-SoVITS/issues/391) で報告された中国語推論品質の低下を引き起こした言語パラメータの混乱を修正しました。
-2. [PR 403](https://github.com/RVC-Boss/GPT-SoVITS/pull/403) で UVR5 を librosa のより高いバージョンに適応させました。
-3. [Commit 14a2851](https://github.com/RVC-Boss/GPT-SoVITS/commit/14a285109a521679f8846589c22da8f656a46ad8) で、`is_half` パラメータがブール値に変換されず、常に半精度推論が行われ、16 シリーズの GPU で `inf` が発生する UVR5 inf everywhereエラーを修正しました。
-4. 英語テキストフロントエンドを最適化しました。
-5. Gradio の依存関係を修正しました。
-6. データセット準備中にルートディレクトリが空白の場合、`.list` フルパスの自動読み取りをサポートしました。
-7. 日本語と英語のために Faster Whisper ASR を統合しました。
+1. [Issue 391](https://github.com/RVC-Boss/GPT-SoVITS/issues/391) で報告された中国語推論品質の低下を引き起こした言語パラメータの混乱を修正しました.
+2. [PR 403](https://github.com/RVC-Boss/GPT-SoVITS/pull/403) で UVR5 を librosa のより高いバージョンに適応させました.
+3. [Commit 14a2851](https://github.com/RVC-Boss/GPT-SoVITS/commit/14a285109a521679f8846589c22da8f656a46ad8) で、`is_half` パラメータがブール値に変換されず、常に半精度推論が行われ、16 シリーズの GPU で `inf` が発生する UVR5 inf everywhereエラーを修正しました.
+4. 英語テキストフロントエンドを最適化しました.
+5. Gradio の依存関係を修正しました.
+6. データセット準備中にルートディレクトリが空白の場合、`.list` フルパスの自動読み取りをサポートしました.
+7. 日本語と英語のために Faster Whisper ASR を統合しました.
 
 ### 20240208 更新
 
-1. [Commit 59f35ad](https://github.com/RVC-Boss/GPT-SoVITS/commit/59f35adad85815df27e9c6b33d420f5ebfd8376b) で、Windows 10 1909 および [Issue 232](https://github.com/RVC-Boss/GPT-SoVITS/issues/232)（繁体字中国語システム言語）での GPT トレーニングのハングを修正する試みを行いました。
+1. [Commit 59f35ad](https://github.com/RVC-Boss/GPT-SoVITS/commit/59f35adad85815df27e9c6b33d420f5ebfd8376b) で、Windows 10 1909 および [Issue 232](https://github.com/RVC-Boss/GPT-SoVITS/issues/232) (繁体字中国語システム言語) での GPT トレーニングのハングを修正する試みを行いました.
 
 ### 20240212 更新
 
-1. Faster Whisper と FunASR のロジックを最適化し、Faster Whisper をミラーダウンロードに切り替えて Hugging Face の接続問題を回避しました。
-2. [PR 457](https://github.com/RVC-Boss/GPT-SoVITS/pull/457) で、GPT の繰り返しと文字欠落を軽減するために、トレーニング中に負のサンプルを構築する実験的なDPO Lossトレーニングオプションを有効にし、いくつかの推論パラメータを推論WebUIで利用可能にしました。
+1. Faster Whisper と FunASR のロジックを最適化し、Faster Whisper をミラーダウンロードに切り替えて Hugging Face の接続問題を回避しました.
+2. [PR 457](https://github.com/RVC-Boss/GPT-SoVITS/pull/457) で、GPT の繰り返しと文字欠落を軽減するために、トレーニング中に負のサンプルを構築する実験的なDPO Lossトレーニングオプションを有効にし、いくつかの推論パラメータを推論WebUIで利用可能にしました.
 
 ### 20240214 更新
 
-1. トレーニングで中国語の実験名をサポート（以前はエラーが発生していました）。
-2. DPOトレーニングを必須ではなくオプション機能に変更。選択された場合、バッチサイズは自動的に半分になります。推論 WebUI で新しいパラメータが渡されない問題を修正しました。
+1. トレーニングで中国語の実験名をサポート (以前はエラーが発生していました).
+2. DPOトレーニングを必須ではなくオプション機能に変更.選択された場合、バッチサイズは自動的に半分になります.推論 WebUI で新しいパラメータが渡されない問題を修正しました.
 
 ### 20240216 更新
 
-1. 参照テキストなしでの入力をサポート。
-2. [Issue 475](https://github.com/RVC-Boss/GPT-SoVITS/issues/475) で報告された中国語フロントエンドのバグを修正しました。
+1. 参照テキストなしでの入力をサポート.
+2. [Issue 475](https://github.com/RVC-Boss/GPT-SoVITS/issues/475) で報告された中国語フロントエンドのバグを修正しました.
 
 ### 20240221 更新
 
-1. データ処理中のノイズ低減オプションを追加（ノイズ低減は16kHzサンプリングレートのみを残します；背景ノイズが大きい場合にのみ使用してください）。
-2. [PR 559](https://github.com/RVC-Boss/GPT-SoVITS/pull/559), [PR 556](https://github.com/RVC-Boss/GPT-SoVITS/pull/556), [PR 532](https://github.com/RVC-Boss/GPT-SoVITS/pull/532), [PR 507](https://github.com/RVC-Boss/GPT-SoVITS/pull/507), [PR 509](https://github.com/RVC-Boss/GPT-SoVITS/pull/509) で中国語と日本語のフロントエンド処理を最適化しました。
-3. Mac CPU 推論を MPS ではなく CPU を使用するように切り替え、パフォーマンスを向上させました。
-4. Colab のパブリック URL の問題を修正しました。
+1. データ処理中のノイズ低減オプションを追加 (ノイズ低減は16kHzサンプリングレートのみを残します；背景ノイズが大きい場合にのみ使用してください).
+2. [PR 559](https://github.com/RVC-Boss/GPT-SoVITS/pull/559), [PR 556](https://github.com/RVC-Boss/GPT-SoVITS/pull/556), [PR 532](https://github.com/RVC-Boss/GPT-SoVITS/pull/532), [PR 507](https://github.com/RVC-Boss/GPT-SoVITS/pull/507), [PR 509](https://github.com/RVC-Boss/GPT-SoVITS/pull/509) で中国語と日本語のフロントエンド処理を最適化しました.
+3. Mac CPU 推論を MPS ではなく CPU を使用するように切り替え、パフォーマンスを向上させました.
+4. Colab のパブリック URL の問題を修正しました.
 ### 20240306 更新
 
-1. [PR 672](https://github.com/RVC-Boss/GPT-SoVITS/pull/672) で推論速度を50%向上させました（RTX3090 + PyTorch 2.2.1 + CU11.8 + Win10 + Py39 でテスト）。
-2. Faster Whisper非中国語ASRを使用する際、最初に中国語FunASRモデルをダウンロードする必要がなくなりました。
-3. [PR 610](https://github.com/RVC-Boss/GPT-SoVITS/pull/610) で UVR5 残響除去モデルの設定が逆になっていた問題を修正しました。
-4. [PR 675](https://github.com/RVC-Boss/GPT-SoVITS/pull/675) で、CUDA が利用できない場合に Faster Whisper の自動 CPU 推論を有効にしました。
-5. [PR 573](https://github.com/RVC-Boss/GPT-SoVITS/pull/573) で、Mac での適切なCPU推論を確保するために `is_half` チェックを修正しました。
+1. [PR 672](https://github.com/RVC-Boss/GPT-SoVITS/pull/672) で推論速度を50%向上させました (RTX3090 + PyTorch 2.2.1 + CU11.8 + Win10 + Py39 でテスト).
+2. Faster Whisper非中国語ASRを使用する際、最初に中国語FunASRモデルをダウンロードする必要がなくなりました.
+3. [PR 610](https://github.com/RVC-Boss/GPT-SoVITS/pull/610) で UVR5 残響除去モデルの設定が逆になっていた問題を修正しました.
+4. [PR 675](https://github.com/RVC-Boss/GPT-SoVITS/pull/675) で、CUDA が利用できない場合に Faster Whisper の自動 CPU 推論を有効にしました.
+5. [PR 573](https://github.com/RVC-Boss/GPT-SoVITS/pull/573) で、Mac での適切なCPU推論を確保するために `is_half` チェックを修正しました.
 
 ### 202403/202404/202405 更新
 
 #### マイナー修正:
 
-1. 参照テキストなしモードの問題を修正しました。
-2. 中国語と英語のテキストフロントエンドを最適化しました。
-3. API フォーマットを改善しました。
-4. CMD フォーマットの問題を修正しました。
-5. トレーニングデータ処理中のサポートされていない言語に対するエラープロンプトを追加しました。
-6. Hubert 抽出のバグを修正しました。
+1. 参照テキストなしモードの問題を修正しました.
+2. 中国語と英語のテキストフロントエンドを最適化しました.
+3. API フォーマットを改善しました.
+4. CMD フォーマットの問題を修正しました.
+5. トレーニングデータ処理中のサポートされていない言語に対するエラープロンプトを追加しました.
+6. Hubert 抽出のバグを修正しました.
 
 #### メジャー修正:
 
-1. SoVITS トレーニングで VQ を凍結せずに品質低下を引き起こす問題を修正しました。
-2. クイック推論ブランチを追加しました。
+1. SoVITS トレーニングで VQ を凍結せずに品質低下を引き起こす問題を修正しました.
+2. クイック推論ブランチを追加しました.
 
 ### 20240610 更新
 
 #### マイナー修正:
 
-1. [PR 1168](https://github.com/RVC-Boss/GPT-SoVITS/pull/1168) & [PR 1169](https://github.com/RVC-Boss/GPT-SoVITS/pull/1169)で、純粋な句読点および複数の句読点を含むテキスト入力のロジックを改善しました。
-2. [Commit 501a74a](https://github.com/RVC-Boss/GPT-SoVITS/commit/501a74ae96789a26b48932babed5eb4e9483a232)で、UVR5 の MDXNet デリバブをサポートする CMD フォーマットを修正し、スペースを含むパスをサポートしました。
-3. [PR 1159](https://github.com/RVC-Boss/GPT-SoVITS/pull/1159)で、`s2_train.py` の SoVITS トレーニングのプログレスバーロジックを修正しました。
+1. [PR 1168](https://github.com/RVC-Boss/GPT-SoVITS/pull/1168) & [PR 1169](https://github.com/RVC-Boss/GPT-SoVITS/pull/1169)で、純粋な句読点および複数の句読点を含むテキスト入力のロジックを改善しました.
+2. [Commit 501a74a](https://github.com/RVC-Boss/GPT-SoVITS/commit/501a74ae96789a26b48932babed5eb4e9483a232)で、UVR5 の MDXNet デリバブをサポートする CMD フォーマットを修正し、スペースを含むパスをサポートしました.
+3. [PR 1159](https://github.com/RVC-Boss/GPT-SoVITS/pull/1159)で、`s2_train.py` の SoVITS トレーニングのプログレスバーロジックを修正しました.
 
 #### メジャー修正:
 
-4. [Commit 99f09c8](https://github.com/RVC-Boss/GPT-SoVITS/commit/99f09c8bdc155c1f4272b511940717705509582a) で、WebUI の GPT ファインチューニングが中国語入力テキストの BERT 特徴を読み取らず、推論との不一致や品質低下の可能性を修正しました。
-   **注意: 以前に大量のデータでファインチューニングを行った場合、品質向上のためにモデルを再調整することをお勧めします。**
+4. [Commit 99f09c8](https://github.com/RVC-Boss/GPT-SoVITS/commit/99f09c8bdc155c1f4272b511940717705509582a) で、WebUI の GPT ファインチューニングが中国語入力テキストの BERT 特徴を読み取らず、推論との不一致や品質低下の可能性を修正しました.
+   **注意: 以前に大量のデータでファインチューニングを行った場合、品質向上のためにモデルを再調整することをお勧めします.**
 
 ### 20240706 更新
 
 #### マイナー修正:
 
-1. [Commit 1250670](https://github.com/RVC-Boss/GPT-SoVITS/commit/db50670598f0236613eefa6f2d5a23a271d82041) で、CPU 推論のデフォルトバッチサイズの小数点問題を修正しました。
-2. [PR 1258](https://github.com/RVC-Boss/GPT-SoVITS/pull/1258), [PR 1265](https://github.com/RVC-Boss/GPT-SoVITS/pull/1265), [PR 1267](https://github.com/RVC-Boss/GPT-SoVITS/pull/1267) で、ノイズ除去またはASRが例外に遭遇した場合に、すべての保留中のオーディオファイルが終了する問題を修正しました。
-3. [PR 1253](https://github.com/RVC-Boss/GPT-SoVITS/pull/1253) で、句読点で分割する際の小数点分割の問題を修正しました。
-4. [Commit a208698](https://github.com/RVC-Boss/GPT-SoVITS/commit/a208698e775155efc95b187b746d153d0f2847ca) で、マルチGPUトレーニングのマルチプロセス保存ロジックを修正しました。
-5. [PR 1251](https://github.com/RVC-Boss/GPT-SoVITS/pull/1251) で、不要な `my_utils` を削除しました。
+1. [Commit 1250670](https://github.com/RVC-Boss/GPT-SoVITS/commit/db50670598f0236613eefa6f2d5a23a271d82041) で、CPU 推論のデフォルトバッチサイズの小数点問題を修正しました.
+2. [PR 1258](https://github.com/RVC-Boss/GPT-SoVITS/pull/1258), [PR 1265](https://github.com/RVC-Boss/GPT-SoVITS/pull/1265), [PR 1267](https://github.com/RVC-Boss/GPT-SoVITS/pull/1267) で、ノイズ除去またはASRが例外に遭遇した場合に、すべての保留中のオーディオファイルが終了する問題を修正しました.
+3. [PR 1253](https://github.com/RVC-Boss/GPT-SoVITS/pull/1253) で、句読点で分割する際の小数点分割の問題を修正しました.
+4. [Commit a208698](https://github.com/RVC-Boss/GPT-SoVITS/commit/a208698e775155efc95b187b746d153d0f2847ca) で、マルチGPUトレーニングのマルチプロセス保存ロジックを修正しました.
+5. [PR 1251](https://github.com/RVC-Boss/GPT-SoVITS/pull/1251) で、不要な `my_utils` を削除しました.
 
 #### メジャー修正:
 
-6. [PR 672](https://github.com/RVC-Boss/GPT-SoVITS/pull/672) の加速推論コードが検証され、メインブランチにマージされ、ベースとの推論効果の一貫性が確保されました。
-   また、参照テキストなしモードでの加速推論もサポートしています。
+6. [PR 672](https://github.com/RVC-Boss/GPT-SoVITS/pull/672) の加速推論コードが検証され、メインブランチにマージされ、ベースとの推論効果の一貫性が確保されました.
+   また、参照テキストなしモードでの加速推論もサポートしています.
 
-**今後の更新では、`fast_inference`ブランチの変更の一貫性を継続的に検証します**。
+**今後の更新では、`fast_inference`ブランチの変更の一貫性を継続的に検証します**.
 
 ### 20240727 更新
 
 #### マイナー修正:
 
-1. [PR 1298](https://github.com/RVC-Boss/GPT-SoVITS/pull/1298) で、不要な i18n コードをクリーンアップしました。
-2. [PR 1299](https://github.com/RVC-Boss/GPT-SoVITS/pull/1299) で、ユーザーファイルパスの末尾のスラッシュがコマンドラインエラーを引き起こす問題を修正しました。
-3. [PR 756](https://github.com/RVC-Boss/GPT-SoVITS/pull/756) で、GPT トレーニングのステップ計算ロジックを修正しました。
+1. [PR 1298](https://github.com/RVC-Boss/GPT-SoVITS/pull/1298) で、不要な i18n コードをクリーンアップしました.
+2. [PR 1299](https://github.com/RVC-Boss/GPT-SoVITS/pull/1299) で、ユーザーファイルパスの末尾のスラッシュがコマンドラインエラーを引き起こす問題を修正しました.
+3. [PR 756](https://github.com/RVC-Boss/GPT-SoVITS/pull/756) で、GPT トレーニングのステップ計算ロジックを修正しました.
 
 #### メジャー修正:
 
-4. [Commit 9588a3c](https://github.com/RVC-Boss/GPT-SoVITS/commit/9588a3c52d9ebdb20b3c5d74f647d12e7c1171c2) で、合成のスピーチレート調整をサポートしました。
-   スピーチレートのみを調整しながらランダム性を固定できるようになりました。
+4. [Commit 9588a3c](https://github.com/RVC-Boss/GPT-SoVITS/commit/9588a3c52d9ebdb20b3c5d74f647d12e7c1171c2) で、合成のスピーチレート調整をサポートしました.
+   スピーチレートのみを調整しながらランダム性を固定できるようになりました.
 
 ### 20240806 更新
 
-1. [PR 1306](https://github.com/RVC-Boss/GPT-SoVITS/pull/1306)、[PR 1356](https://github.com/RVC-Boss/GPT-SoVITS/pull/1356) BS RoFormer ボーカルアコムパニ分離モデルのサポートを追加しました。[Commit e62e965](https://github.com/RVC-Boss/GPT-SoVITS/commit/e62e965323a60a76a025bcaa45268c1ddcbcf05c) FP16 推論を有効にしました。
-2. 中国語テキストフロントエンドを改善しました。
-   - [PR 488](https://github.com/RVC-Boss/GPT-SoVITS/pull/488) 多音字のサポートを追加（v2 のみ）;
+1. [PR 1306](https://github.com/RVC-Boss/GPT-SoVITS/pull/1306)、[PR 1356](https://github.com/RVC-Boss/GPT-SoVITS/pull/1356) BS RoFormer ボーカルアコムパニ分離モデルのサポートを追加しました.[Commit e62e965](https://github.com/RVC-Boss/GPT-SoVITS/commit/e62e965323a60a76a025bcaa45268c1ddcbcf05c) FP16 推論を有効にしました.
+2. 中国語テキストフロントエンドを改善しました.
+   - [PR 488](https://github.com/RVC-Boss/GPT-SoVITS/pull/488) 多音字のサポートを追加 (v2 のみ);
    - [PR 987](https://github.com/RVC-Boss/GPT-SoVITS/pull/987) 量詞を追加;
    - [PR 1351](https://github.com/RVC-Boss/GPT-SoVITS/pull/1351) 四則演算と基本数式のサポート;
-   - [PR 1404](https://github.com/RVC-Boss/GPT-SoVITS/pull/1404) 混合テキストエラーを修正。
-3. [PR 1355](https://github.com/RVC-Boss/GPT-SoVITS/pull/1356) WebUIでオーディオ処理時にパスを自動入力しました。
-4. [Commit bce451a](https://github.com/RVC-Boss/GPT-SoVITS/commit/bce451a2d1641e581e200297d01f219aeaaf7299), [Commit 4c8b761](https://github.com/RVC-Boss/GPT-SoVITS/commit/4c8b7612206536b8b4435997acb69b25d93acb78) GPU 認識ロジックを最適化しました。
-5. [Commit 8a10147](https://github.com/RVC-Boss/GPT-SoVITS/commit/8a101474b5a4f913b4c94fca2e3ca87d0771bae3) 広東語ASRのサポートを追加しました。
-6. GPT-SoVITS v2 のサポートを追加しました。
-7. [PR 1387](https://github.com/RVC-Boss/GPT-SoVITS/pull/1387) タイミングロジックを最適化しました。
+   - [PR 1404](https://github.com/RVC-Boss/GPT-SoVITS/pull/1404) 混合テキストエラーを修正.
+3. [PR 1355](https://github.com/RVC-Boss/GPT-SoVITS/pull/1356) WebUIでオーディオ処理時にパスを自動入力しました.
+4. [Commit bce451a](https://github.com/RVC-Boss/GPT-SoVITS/commit/bce451a2d1641e581e200297d01f219aeaaf7299), [Commit 4c8b761](https://github.com/RVC-Boss/GPT-SoVITS/commit/4c8b7612206536b8b4435997acb69b25d93acb78) GPU 認識ロジックを最適化しました.
+5. [Commit 8a10147](https://github.com/RVC-Boss/GPT-SoVITS/commit/8a101474b5a4f913b4c94fca2e3ca87d0771bae3) 広東語ASRのサポートを追加しました.
+6. GPT-SoVITS v2 のサポートを追加しました.
+7. [PR 1387](https://github.com/RVC-Boss/GPT-SoVITS/pull/1387) タイミングロジックを最適化しました.
 
 ### 20240821 更新
 
-1. [PR 1490](https://github.com/RVC-Boss/GPT-SoVITS/pull/1490) `fast_inference` ブランチをメインブランチにマージしました。
-2. [Issue 1508](https://github.com/RVC-Boss/GPT-SoVITS/issues/1508) SSMLタグを使用して数字、電話番号、日付、時間などの最適化をサポートしました。
-3. [PR 1503](https://github.com/RVC-Boss/GPT-SoVITS/pull/1503) APIの修正と最適化を行いました。
-4. [PR 1422](https://github.com/RVC-Boss/GPT-SoVITS/pull/1422) 参照音声のミキシングで1つしかアップロードできないバグを修正し、データセットの各種チェックを追加してファイルが欠落している場合に警告を表示するようにしました。
+1. [PR 1490](https://github.com/RVC-Boss/GPT-SoVITS/pull/1490) `fast_inference` ブランチをメインブランチにマージしました.
+2. [Issue 1508](https://github.com/RVC-Boss/GPT-SoVITS/issues/1508) SSMLタグを使用して数字、電話番号、日付、時間などの最適化をサポートしました.
+3. [PR 1503](https://github.com/RVC-Boss/GPT-SoVITS/pull/1503) APIの修正と最適化を行いました.
+4. [PR 1422](https://github.com/RVC-Boss/GPT-SoVITS/pull/1422) 参照音声のミキシングで1つしかアップロードできないバグを修正し、データセットの各種チェックを追加してファイルが欠落している場合に警告を表示するようにしました.
 
 ### 20250211 更新
 
-1. [Wiki](https://github.com/RVC-Boss/GPT-SoVITS/wiki/GPT%E2%80%90SoVITS%E2%80%90v3%E2%80%90features-(%E6%96%B0%E7%89%B9%E6%80%A7)) GPT-SoVITS v3 モデルを追加しました。SoVITS v3のファインチューニングには14GBのGPUメモリが必要です。
+1. [Wiki](https://github.com/RVC-Boss/GPT-SoVITS/wiki/GPT%E2%80%90SoVITS%E2%80%90v3%E2%80%90features-(%E6%96%B0%E7%89%B9%E6%80%A7)) GPT-SoVITS v3 モデルを追加しました.SoVITS v3のファインチューニングには14GBのGPUメモリが必要です.
 
 ### 20250212 更新
 
-- [PR 2040](https://github.com/RVC-Boss/GPT-SoVITS/pull/2040) SoVITS v3のファインチューニングにグラデーションチェックポイントを追加、12GBのGPUメモリが必要です。
+- [PR 2040](https://github.com/RVC-Boss/GPT-SoVITS/pull/2040) SoVITS v3のファインチューニングにグラデーションチェックポイントを追加、12GBのGPUメモリが必要です.
 
 ### 20250214 更新
 
-- [PR 2047](https://github.com/RVC-Boss/GPT-SoVITS/pull/2047) 多言語混合テキスト分割戦略の最適化 **A**。
-  - `split-lang`を言語分割ツールとして追加し、多言語混合テキストの分割能力を向上させました。
+- [PR 2047](https://github.com/RVC-Boss/GPT-SoVITS/pull/2047) 多言語混合テキスト分割戦略の最適化 **A**.
+  - `split-lang`を言語分割ツールとして追加し、多言語混合テキストの分割能力を向上させました.
 
 ### 20250217 更新
 
-- [PR 2062](https://github.com/RVC-Boss/GPT-SoVITS/pull/2062) テキスト内の数字と英語の処理ロジックを最適化。
+- [PR 2062](https://github.com/RVC-Boss/GPT-SoVITS/pull/2062) テキスト内の数字と英語の処理ロジックを最適化.
 
 ### 20250218 更新
 
-- [PR 2073](https://github.com/RVC-Boss/GPT-SoVITS/pull/2073) 多言語混合テキスト分割戦略の最適化 **B**。
+- [PR 2073](https://github.com/RVC-Boss/GPT-SoVITS/pull/2073) 多言語混合テキスト分割戦略の最適化 **B**.
 
 ### 20250223 更新
 
-1. LoRAトレーニングがSoVITS V3のファインチューニングに対応しました。8GBのGPUメモリが必要で、結果はフルパラメータファインチューニングより優れています。
-2. [PR 2078](https://github.com/RVC-Boss/GPT-SoVITS/pull/2078) ボーカルと楽器分離のためにMel Band RoFormerモデルを追加しました。
+1. LoRAトレーニングがSoVITS V3のファインチューニングに対応しました.8GBのGPUメモリが必要で、結果はフルパラメータファインチューニングより優れています.
+2. [PR 2078](https://github.com/RVC-Boss/GPT-SoVITS/pull/2078) ボーカルと楽器分離のためにMel Band RoFormerモデルを追加しました.
 
 ### 20250226 更新
 
-1. [PR 2112](https://github.com/RVC-Boss/GPT-SoVITS/pull/2112) Windowsでの非英語ディレクトリによる問題を修正しました。
-   - `langsegmenter`を使用して韓国語の問題を修正。
-2. [PR 2113](https://github.com/RVC-Boss/GPT-SoVITS/pull/2114) Windowsでの非英語ディレクトリによる問題を修正しました。
-   - `langsegmenter`を使用して韓国語/日本語の問題を修正。
+1. [PR 2112](https://github.com/RVC-Boss/GPT-SoVITS/pull/2112) Windowsでの非英語ディレクトリによる問題を修正しました.
+   - `langsegmenter`を使用して韓国語の問題を修正.
+2. [PR 2113](https://github.com/RVC-Boss/GPT-SoVITS/pull/2114) Windowsでの非英語ディレクトリによる問題を修正しました.
+   - `langsegmenter`を使用して韓国語/日本語の問題を修正.
 
 ### 20250227 更新
 
-- V3モデルで24Kオーディオを生成する際に発生するこもった音の問題を緩和するために、24Kから48Kのオーディオ超解像モデルを追加しました。[Issue 2085](https://github.com/RVC-Boss/GPT-SoVITS/issues/2085)、[Issue 2117](https://github.com/RVC-Boss/GPT-SoVITS/issues/2117)で報告されています。
+- V3モデルで24Kオーディオを生成する際に発生するこもった音の問題を緩和するために、24Kから48Kのオーディオ超解像モデルを追加しました.[Issue 2085](https://github.com/RVC-Boss/GPT-SoVITS/issues/2085)、[Issue 2117](https://github.com/RVC-Boss/GPT-SoVITS/issues/2117)で報告されています.

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 
 <h1>GPT-SoVITS-WebUI</h1>
-パワフルなFew-Shot音声変換・音声合成 WebUI。<br><br>
+パワフルなFew-Shot音声変換・音声合成 WebUI.<br><br>
 
 [![madewithlove](https://img.shields.io/badge/made_with-%E2%9D%A4-red?style=for-the-badge&labelColor=orange)](https://github.com/RVC-Boss/GPT-SoVITS)
 
@@ -20,13 +20,13 @@
 
 ## 機能:
 
-1. **Zero-Shot TTS:** たった 5 秒間の音声サンプルで、即座にテキストからその音声に変換できます。
+1. **Zero-Shot TTS:** たった 5 秒間の音声サンプルで、即座にテキストからその音声に変換できます.
 
-2. **Few-Shot TTS:** わずか 1 分間のトレーニングデータでモデルを微調整し、音声のクオリティを向上。
+2. **Few-Shot TTS:** わずか 1 分間のトレーニングデータでモデルを微調整し、音声のクオリティを向上.
 
-3. **多言語サポート:** 現在、英語、日本語、韓国語、広東語、中国語をサポートしています。
+3. **多言語サポート:** 現在、英語、日本語、韓国語、広東語、中国語をサポートしています.
 
-4. **WebUI ツール:** 統合されたツールは、音声と伴奏（BGM 等）の分離、トレーニングセットの自動セグメンテーション、ASR（中国語のみ）、テキストラベリング等を含むため、初心者の方でもトレーニングデータセットの作成や GPT/SoVITS モデルのトレーニング等を非常に簡単に行えます。
+4. **WebUI ツール:** 統合されたツールは、音声と伴奏 (BGM 等) の分離、トレーニングセットの自動セグメンテーション、ASR (中国語のみ)、テキストラベリング等を含むため、初心者の方でもトレーニングデータセットの作成や GPT/SoVITS モデルのトレーニング等を非常に簡単に行えます.
 
 **[デモ動画](https://www.bilibili.com/video/BV12g4y1m7Uw)をチェック！**
 
@@ -40,16 +40,18 @@ https://github.com/RVC-Boss/GPT-SoVITS/assets/129054828/05bee1fa-bdd8-4d85-9350-
 
 ### テスト済みの環境
 
-- Python 3.9, PyTorch 2.0.1, CUDA 11
-- Python 3.10.13, PyTorch 2.1.2, CUDA 12.3
-- Python 3.9, PyTorch 2.2.2, macOS 14.4.1 (Apple silicon)
-- Python 3.9, PyTorch 2.2.2, CPU デバイス
-
-_注記: numba==0.56.4 は py<3.11 が必要です_
+| Python Version | PyTorch Version  | Device          |
+|----------------|------------------|-----------------|
+| Python 3.9     | PyTorch 2.0.1    | CUDA 11.8       |
+| Python 3.10.13 | PyTorch 2.1.2    | CUDA 12.3       |
+| Python 3.10.17 | PyTorch 2.5.1    | CUDA 12.4       |
+| Python 3.9     | PyTorch 2.5.1    | Apple silicon   |
+| Python 3.11    | PyTorch 2.6.0    | Apple silicon   |
+| Python 3.9     | PyTorch 2.2.2    | CPU             |
 
 ### Windows
 
-Windows ユーザー:（Windows 10 以降でテスト済み）、[統合パッケージをダウンロード](https://huggingface.co/lj1995/GPT-SoVITS-windows-package/resolve/main/GPT-SoVITS-v3lora-20250228.7z?download=true)し、解凍後に _go-webui.bat_ をダブルクリックすると、GPT-SoVITS-WebUI が起動します。
+Windows ユーザー: (Windows 10 以降でテスト済み)、[統合パッケージをダウンロード](https://huggingface.co/lj1995/GPT-SoVITS-windows-package/resolve/main/GPT-SoVITS-v3lora-20250228.7z?download=true)し、解凍後に _go-webui.bat_ をダブルクリックすると、GPT-SoVITS-WebUI が起動します.
 
 ### Linux
 
@@ -61,11 +63,11 @@ bash install.sh
 
 ### macOS
 
-**注：Mac で GPU を使用して訓練されたモデルは、他のデバイスで訓練されたモデルと比較して著しく品質が低下するため、当面は CPU を使用して訓練することを強く推奨します。**
+**注: Mac で GPU を使用して訓練されたモデルは、他のデバイスで訓練されたモデルと比較して著しく品質が低下するため、当面は CPU を使用して訓練することを強く推奨します.**
 
-1. `xcode-select --install` を実行して、Xcode コマンドラインツールをインストールします。
-2. `brew install ffmpeg` を実行して FFmpeg をインストールします。
-3. 上記の手順を完了した後、以下のコマンドを実行してこのプロジェクトをインストールします。
+1. `xcode-select --install` を実行して、Xcode コマンドラインツールをインストールします.
+2. `brew install ffmpeg` を実行して FFmpeg をインストールします.
+3. 上記の手順を完了した後、以下のコマンドを実行してこのプロジェクトをインストールします.
 
 ```bash
 conda create -n GPTSoVits python=3.9
@@ -76,7 +78,7 @@ pip install -r requirements.txt
 
 ### 手動インストール
 
-#### FFmpeg をインストールします。
+#### FFmpeg をインストールします.
 
 ##### Conda ユーザー
 
@@ -94,7 +96,7 @@ conda install -c conda-forge 'ffmpeg<7'
 
 ##### Windows ユーザー
 
-[ffmpeg.exe](https://huggingface.co/lj1995/VoiceConversionWebUI/blob/main/ffmpeg.exe) と [ffprobe.exe](https://huggingface.co/lj1995/VoiceConversionWebUI/blob/main/ffprobe.exe) をダウンロードし、GPT-SoVITS のルートフォルダに置きます。
+[ffmpeg.exe](https://huggingface.co/lj1995/VoiceConversionWebUI/blob/main/ffmpeg.exe) と [ffprobe.exe](https://huggingface.co/lj1995/VoiceConversionWebUI/blob/main/ffprobe.exe) をダウンロードし、GPT-SoVITS のルートフォルダに置きます.
 
 ##### MacOS ユーザー
 
@@ -113,14 +115,14 @@ pip install -r requirementx.txt
 
 #### docker-compose.yaml の設定
 
-0. イメージのタグについて：コードベースの更新が速い割に、イメージのパッケージングとテストが遅いため、[Docker Hub](https://hub.docker.com/r/breakstring/gpt-sovits) で現在パッケージされている最新のイメージをご覧になり、ご自身の状況に応じて選択するか、またはご自身のニーズに応じて Dockerfile を使用してローカルでビルドしてください。
-1. 環境変数：
+0. イメージのタグについて: コードベースの更新が速い割に、イメージのパッケージングとテストが遅いため、[Docker Hub](https://hub.docker.com/r/breakstring/gpt-sovits)(古いバージョン) で現在パッケージされている最新のイメージをご覧になり、ご自身の状況に応じて選択するか、またはご自身のニーズに応じて Dockerfile を使用してローカルでビルドしてください.
+1. 環境変数: 
 
-   - `is_half`：半精度／倍精度の制御。"SSL 抽出"ステップ中に`4-cnhubert/5-wav32k`ディレクトリ内の内容が正しく生成されない場合、通常これが原因です。実際の状況に応じて True または False に調整してください。
+   - `is_half`: 半精度／倍精度の制御."SSL 抽出"ステップ中に`4-cnhubert/5-wav32k`ディレクトリ内の内容が正しく生成されない場合、通常これが原因です.実際の状況に応じて True または False に調整してください.
 
-2. ボリューム設定：コンテナ内のアプリケーションのルートディレクトリは`/workspace`に設定されます。デフォルトの`docker-compose.yaml`には、アップロード／ダウンロードの内容の実例がいくつか記載されています。
-3. `shm_size`：Windows の Docker Desktop のデフォルトの利用可能メモリは小さすぎるため、うまく動作しない可能性があります。状況に応じて適宜設定してください。
-4. `deploy`セクションの GPU に関連する内容は、システムと実際の状況に応じて慎重に設定してください。
+2. ボリューム設定: コンテナ内のアプリケーションのルートディレクトリは`/workspace`に設定されます.デフォルトの`docker-compose.yaml`には、アップロード／ダウンロードの内容の実例がいくつか記載されています.
+3. `shm_size`: Windows の Docker Desktop のデフォルトの利用可能メモリは小さすぎるため、うまく動作しない可能性があります.状況に応じて適宜設定してください.
+4. `deploy`セクションの GPU に関連する内容は、システムと実際の状況に応じて慎重に設定してください.
 
 #### docker compose で実行する
 
@@ -130,7 +132,7 @@ docker compose -f "docker-compose.yaml" up -d
 
 #### docker コマンドで実行する
 
-上記と同様に、実際の状況に基づいて対応するパラメータを変更し、次のコマンドを実行します：
+上記と同様に、実際の状況に基づいて対応するパラメータを変更し、次のコマンドを実行します: 
 
 ```markdown
 docker run --rm -it --gpus=all --env=is_half=False --volume=G:\GPT-SoVITS-DockerTest\output:/workspace/output --volume=G:\GPT-SoVITS-DockerTest\logs:/workspace/logs --volume=G:\GPT-SoVITS-DockerTest\SoVITS_weights:/workspace/SoVITS_weights --workdir=/workspace -p 9880:9880 -p 9871:9871 -p 9872:9872 -p 9873:9873 -p 9874:9874 --shm-size="16G" -d breakstring/gpt-sovits:xxxxx
@@ -138,19 +140,21 @@ docker run --rm -it --gpus=all --env=is_half=False --volume=G:\GPT-SoVITS-Docker
 
 ## 事前訓練済みモデル
 
-1. [GPT-SoVITS Models](https://huggingface.co/lj1995/GPT-SoVITS) から事前訓練済みモデルをダウンロードし、`GPT_SoVITS/pretrained_models` ディレクトリに配置してください。
+**`install.sh`が正常に実行された場合、No.1はスキップしてかまいません.**
 
-2. [G2PWModel_1.1.zip](https://paddlespeech.cdn.bcebos.com/Parakeet/released_models/g2p/G2PWModel_1.1.zip) からモデルをダウンロードし、解凍して `G2PWModel` にリネームし、`GPT_SoVITS/text` ディレクトリに配置してください。（中国語 TTS のみ）
+1. [GPT-SoVITS Models](https://huggingface.co/lj1995/GPT-SoVITS) から事前訓練済みモデルをダウンロードし、`GPT_SoVITS/pretrained_models` ディレクトリに配置してください.
 
-3. UVR5（ボーカル/伴奏（BGM 等）分離 & リバーブ除去の追加機能）の場合は、[UVR5 Weights](https://huggingface.co/lj1995/VoiceConversionWebUI/tree/main/uvr5_weights) からモデルをダウンロードし、`tools/uvr5/uvr5_weights` ディレクトリに配置してください。
+2. [G2PWModel_1.1.zip](https://paddlespeech.cdn.bcebos.com/Parakeet/released_models/g2p/G2PWModel_1.1.zip) からモデルをダウンロードし、解凍して `G2PWModel` にリネームし、`GPT_SoVITS/text` ディレクトリに配置してください. (中国語 TTS のみ)
 
-   - UVR5 で bs_roformer または mel_band_roformer モデルを使用する場合、モデルと対応する設定ファイルを手動でダウンロードし、`tools/UVR5/UVR5_weights`フォルダに配置することができます。**モデルファイルと設定ファイルの名前は、拡張子を除いて同じであることを確認してください**。さらに、モデルと設定ファイルの名前には**「roformer」が含まれている必要があります**。これにより、roformer クラスのモデルとして認識されます。
+3. UVR5 (ボーカル/伴奏 (BGM 等) 分離 & リバーブ除去の追加機能) の場合は、[UVR5 Weights](https://huggingface.co/lj1995/VoiceConversionWebUI/tree/main/uvr5_weights) からモデルをダウンロードし、`tools/uvr5/uvr5_weights` ディレクトリに配置してください.
 
-   - モデル名と設定ファイル名には、**直接モデルタイプを指定することをお勧めします**。例：mel_mand_roformer、bs_roformer。指定しない場合、設定文から特徴を照合して、モデルの種類を特定します。例えば、モデル`bs_roformer_ep_368_sdr_12.9628.ckpt`と対応する設定ファイル`bs_roformer_ep_368_sdr_12.9628.yaml`はペアです。同様に、`kim_mel_band_roformer.ckpt`と`kim_mel_band_roformer.yaml`もペアです。
+   - UVR5 で bs_roformer または mel_band_roformer モデルを使用する場合、モデルと対応する設定ファイルを手動でダウンロードし、`tools/UVR5/UVR5_weights`フォルダに配置することができます.**モデルファイルと設定ファイルの名前は、拡張子を除いて同じであることを確認してください**.さらに、モデルと設定ファイルの名前には**「roformer」が含まれている必要があります**.これにより、roformer クラスのモデルとして認識されます.
 
-4. 中国語 ASR（追加機能）の場合は、[Damo ASR Model](https://modelscope.cn/models/damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch/files)、[Damo VAD Model](https://modelscope.cn/models/damo/speech_fsmn_vad_zh-cn-16k-common-pytorch/files)、および [Damo Punc Model](https://modelscope.cn/models/damo/punc_ct-transformer_zh-cn-common-vocab272727-pytorch/files) からモデルをダウンロードし、`tools/asr/models` ディレクトリに配置してください。
+   - モデル名と設定ファイル名には、**直接モデルタイプを指定することをお勧めします**.例: mel_mand_roformer、bs_roformer.指定しない場合、設定文から特徴を照合して、モデルの種類を特定します.例えば、モデル`bs_roformer_ep_368_sdr_12.9628.ckpt`と対応する設定ファイル`bs_roformer_ep_368_sdr_12.9628.yaml`はペアです.同様に、`kim_mel_band_roformer.ckpt`と`kim_mel_band_roformer.yaml`もペアです.
 
-5. 英語または日本語の ASR（追加機能）を使用する場合は、[Faster Whisper Large V3](https://huggingface.co/Systran/faster-whisper-large-v3) からモデルをダウンロードし、`tools/asr/models` ディレクトリに配置してください。また、[他のモデル](https://huggingface.co/Systran) は、より小さいサイズで高クオリティな可能性があります。
+4. 中国語 ASR (追加機能) の場合は、[Damo ASR Model](https://modelscope.cn/models/damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch/files)、[Damo VAD Model](https://modelscope.cn/models/damo/speech_fsmn_vad_zh-cn-16k-common-pytorch/files)、および [Damo Punc Model](https://modelscope.cn/models/damo/punc_ct-transformer_zh-cn-common-vocab272727-pytorch/files) からモデルをダウンロードし、`tools/asr/models` ディレクトリに配置してください.
+
+5. 英語または日本語の ASR (追加機能) を使用する場合は、[Faster Whisper Large V3](https://huggingface.co/Systran/faster-whisper-large-v3) からモデルをダウンロードし、`tools/asr/models` ディレクトリに配置してください.また、[他のモデル](https://huggingface.co/Systran) は、より小さいサイズで高クオリティな可能性があります.
 
 ## データセット形式
 
@@ -178,8 +182,8 @@ D:\GPT-SoVITS\xxx/xxx.wav|xxx|en|I like playing Genshin.
 
 #### 統合パッケージ利用者
 
-`go-webui.bat`をダブルクリックするか、`go-webui.ps1`を使用します。
-V1 に切り替えたい場合は、`go-webui-v1.bat`をダブルクリックするか、`go-webui-v1.ps1`を使用してください。
+`go-webui.bat`をダブルクリックするか、`go-webui.ps1`を使用します.
+V1 に切り替えたい場合は、`go-webui-v1.bat`をダブルクリックするか、`go-webui-v1.ps1`を使用してください.
 
 #### その他
 
@@ -193,7 +197,7 @@ V1 に切り替えたい場合は
 python webui.py v1 <言語(オプション)>
 ```
 
-または WebUI で手動でバージョンを切り替えてください。
+または WebUI で手動でバージョンを切り替えてください.
 
 ### 微調整
 
@@ -201,7 +205,7 @@ python webui.py v1 <言語(オプション)>
 
     1. 音声パスを入力する
     2. 音声を小さなチャンクに分割する
-    3. ノイズ除去（オプション）
+    3. ノイズ除去 (オプション)
     4. ASR
     5. ASR転写を校正する
     6. 次のタブに移動し、モデルを微調整する
@@ -210,7 +214,7 @@ python webui.py v1 <言語(オプション)>
 
 #### 統合パッケージ利用者
 
-`go-webui-v2.bat`をダブルクリックするか、`go-webui-v2.ps1`を使用して、`1-GPT-SoVITS-TTS/1C-inference`で推論 webui を開きます。
+`go-webui-v2.bat`をダブルクリックするか、`go-webui-v2.ps1`を使用して、`1-GPT-SoVITS-TTS/1C-inference`で推論 webui を開きます.
 
 #### その他
 
@@ -224,7 +228,7 @@ python GPT_SoVITS/inference_webui.py <言語(オプション)>
 python webui.py
 ```
 
-その後、`1-GPT-SoVITS-TTS/1C-inference`で推論 webui を開きます。
+その後、`1-GPT-SoVITS-TTS/1C-inference`で推論 webui を開きます.
 
 ## V2 リリースノート
 
@@ -248,46 +252,46 @@ V1 環境から V2 を使用するには:
 
 3. [huggingface](https://huggingface.co/lj1995/GPT-SoVITS/tree/main/gsv-v2final-pretrained)から V2 の事前学習モデルをダウンロードし、それらを`GPT_SoVITS\pretrained_models\gsv-v2final-pretrained`に配置
 
-   中国語 V2 追加: [G2PWModel_1.1.zip](https://paddlespeech.cdn.bcebos.com/Parakeet/released_models/g2p/G2PWModel_1.1.zip)（G2PW モデルをダウンロードし、解凍して`G2PWModel`にリネームし、`GPT_SoVITS/text`に配置します）
+   中国語 V2 追加: [G2PWModel_1.1.zip](https://paddlespeech.cdn.bcebos.com/Parakeet/released_models/g2p/G2PWModel_1.1.zip) (G2PW モデルをダウンロードし、解凍して`G2PWModel`にリネームし、`GPT_SoVITS/text`に配置します)
 
 ## V3 リリースノート
 
 新機能:
 
-1. 音色の類似性が向上し、ターゲットスピーカーを近似するために必要な学習データが少なくなりました（音色の類似性は、ファインチューニングなしでベースモデルを直接使用することで顕著に改善されます）。
+1. 音色の類似性が向上し、ターゲットスピーカーを近似するために必要な学習データが少なくなりました (音色の類似性は、ファインチューニングなしでベースモデルを直接使用することで顕著に改善されます).
 
-2. GPT モデルがより安定し、繰り返しや省略が減少し、より豊かな感情表現を持つ音声の生成が容易になりました。
+2. GPT モデルがより安定し、繰り返しや省略が減少し、より豊かな感情表現を持つ音声の生成が容易になりました.
 
    [詳細情報はこちら](<https://github.com/RVC-Boss/GPT-SoVITS/wiki/GPT%E2%80%90SoVITS%E2%80%90v3%E2%80%90features-(%E6%96%B0%E7%89%B9%E6%80%A7)>)
 
 v2 環境から v3 を使用する方法:
 
-1. `pip install -r requirements.txt` を実行して、いくつかのパッケージを更新します。
+1. `pip install -r requirements.txt` を実行して、いくつかのパッケージを更新します.
 
-2. GitHub から最新のコードをクローンします。
+2. GitHub から最新のコードをクローンします.
 
-3. v3 の事前学習済みモデル（s1v3.ckpt、s2Gv3.pth、models--nvidia--bigvgan_v2_24khz_100band_256x フォルダ）を[Huggingface](https://huggingface.co/lj1995/GPT-SoVITS/tree/main) からダウンロードし、GPT_SoVITS\pretrained_models フォルダに配置します。
+3. v3 の事前学習済みモデル (s1v3.ckpt、s2Gv3.pth、models--nvidia--bigvgan_v2_24khz_100band_256x フォルダ) を[Huggingface](https://huggingface.co/lj1995/GPT-SoVITS/tree/main) からダウンロードし、GPT_SoVITS\pretrained_models フォルダに配置します.
 
-   追加: 音声超解像モデルについては、[ダウンロード方法](../../tools/AP_BWE_main/24kto48k/readme.txt)を参照してください。
+   追加: 音声超解像モデルについては、[ダウンロード方法](../../tools/AP_BWE_main/24kto48k/readme.txt)を参照してください.
 
 ## Todo リスト
 
 - [x] **優先度 高:**
 
-  - [x] 日本語と英語でのローカライズ。
-  - [x] ユーザーガイド。
-  - [x] 日本語データセットと英語データセットのファインチューニングトレーニング。
+  - [x] 日本語と英語でのローカライズ.
+  - [x] ユーザーガイド.
+  - [x] 日本語データセットと英語データセットのファインチューニングトレーニング.
 
 - [ ] **機能:**
-  - [x] ゼロショット音声変換（5 秒）／数ショット音声変換（1 分）。
-  - [x] TTS スピーキングスピードコントロール。
-  - [ ] ~~TTS の感情コントロールの強化。~~
-  - [ ] SoVITS トークン入力を語彙の確率分布に変更する実験。
-  - [x] 英語と日本語のテキストフロントエンドを改善。
-  - [ ] 小型と大型の TTS モデルを開発する。
-  - [x] Colab のスクリプト。
-  - [ ] トレーニングデータセットを拡張する（2k→10k）。
-  - [x] より良い sovits ベースモデル（音質向上）
+  - [x] ゼロショット音声変換 (5 秒) ／数ショット音声変換 (1 分).
+  - [x] TTS スピーキングスピードコントロール.
+  - [ ] ~~TTS の感情コントロールの強化.~~
+  - [ ] SoVITS トークン入力を語彙の確率分布に変更する実験.
+  - [x] 英語と日本語のテキストフロントエンドを改善.
+  - [ ] 小型と大型の TTS モデルを開発する.
+  - [x] Colab のスクリプト.
+  - [ ] トレーニングデータセットを拡張する (2k→10k).
+  - [x] より良い sovits ベースモデル (音質向上)
   - [ ] モデルミックス
 
 ## (追加の) コマンドラインから実行する方法
@@ -298,12 +302,12 @@ v2 環境から v3 を使用する方法:
 python tools/uvr5/webui.py "<infer_device>" <is_half> <webui_port_uvr5>
 ```
 
-<!-- ブラウザを開けない場合は、以下の形式に従って UVR 処理を行ってください。これはオーディオ処理に mdxnet を使用しています。
+<!-- ブラウザを開けない場合は、以下の形式に従って UVR 処理を行ってください.これはオーディオ処理に mdxnet を使用しています.
 ```
 python mdxnet.py --model --input_root --output_vocal --output_ins --agg_level --format --device --is_half_precision
 ``` -->
 
-コマンド ラインを使用してデータセットのオーディオ セグメンテーションを行う方法は次のとおりです。
+コマンド ラインを使用してデータセットのオーディオ セグメンテーションを行う方法は次のとおりです.
 
 ```
 python audio_slicer.py \
@@ -323,7 +327,7 @@ python tools/asr/funasr_asr.py -i <input> -o <output>
 
 ASR 処理は Faster_Whisper を通じて実行されます(中国語を除く ASR マーキング)
 
-(進行状況バーは表示されません。GPU のパフォーマンスにより時間遅延が発生する可能性があります)
+(進行状況バーは表示されません.GPU のパフォーマンスにより時間遅延が発生する可能性があります)
 
 ```
 python ./tools/asr/fasterwhisper_asr.py -i <input> -o <output> -l <language> -p <precision>
@@ -333,7 +337,7 @@ python ./tools/asr/fasterwhisper_asr.py -i <input> -o <output> -l <language> -p 
 
 ## クレジット
 
-特に以下のプロジェクトと貢献者に感謝します：
+特に以下のプロジェクトと貢献者に感謝します: 
 
 ### 理論研究
 
@@ -372,7 +376,7 @@ python ./tools/asr/fasterwhisper_asr.py -i <input> -o <output> -l <language> -p 
 - [FunASR](https://github.com/alibaba-damo-academy/FunASR)
 - [AP-BWE](https://github.com/yxlu-0102/AP-BWE)
 
-@Naozumi520 さん、広東語のトレーニングセットの提供と、広東語に関する知識のご指導をいただき、感謝申し上げます。
+@Naozumi520 さん、広東語のトレーニングセットの提供と、広東語に関する知識のご指導をいただき、感謝申し上げます.
 
 ## すべてのコントリビューターに感謝します
 

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -40,12 +40,14 @@ https://github.com/RVC-Boss/GPT-SoVITS/assets/129054828/05bee1fa-bdd8-4d85-9350-
 
 ### 테스트 통과 환경
 
-- Python 3.9, PyTorch 2.0.1, CUDA 11
-- Python 3.10.13, PyTorch 2.1.2, CUDA 12.3
-- Python 3.9, Pytorch 2.2.2, macOS 14.4.1 (Apple Slilicon)
-- Python 3.9, PyTorch 2.2.2, CPU 장치
-
-_참고: numba==0.56.4 는 python<3.11 을 필요로 합니다._
+| Python Version | PyTorch Version  | Device          |
+|----------------|------------------|-----------------|
+| Python 3.9     | PyTorch 2.0.1    | CUDA 11.8       |
+| Python 3.10.13 | PyTorch 2.1.2    | CUDA 12.3       |
+| Python 3.10.17 | PyTorch 2.5.1    | CUDA 12.4       |
+| Python 3.9     | PyTorch 2.5.1    | Apple silicon   |
+| Python 3.11    | PyTorch 2.6.0    | Apple silicon   |
+| Python 3.9     | PyTorch 2.2.2    | CPU             |
 
 ### Windows
 
@@ -115,7 +117,7 @@ pip install -r requirements.txt
 
 #### docker-compose.yaml 설정
 
-0. 이미지 태그: 코드 저장소가 빠르게 업데이트되고 패키지가 느리게 빌드되고 테스트되므로, 현재 빌드된 최신 도커 이미지를 [Docker Hub](https://hub.docker.com/r/breakstring/gpt-sovits)에서 확인하고 필요에 따라 Dockerfile을 사용하여 로컬에서 빌드할 수 있습니다.
+0. 이미지 태그: 코드 저장소가 빠르게 업데이트되고 패키지가 느리게 빌드되고 테스트되므로, 현재 빌드된 최신 도커 이미지를 [Docker Hub](https://hub.docker.com/r/breakstring/gpt-sovits)(오래된 버전) 에서 확인하고 필요에 따라 Dockerfile을 사용하여 로컬에서 빌드할 수 있습니다.
 
 1. 환경 변수:
 
@@ -142,6 +144,8 @@ docker run --rm -it --gpus=all --env=is_half=False --volume=G:\GPT-SoVITS-Docker
 ```
 
 ## 사전 학습된 모델
+
+**`install.sh`가 성공적으로 실행되면 No.1은 건너뛰어도 됩니다.**
 
 1. [GPT-SoVITS Models](https://huggingface.co/lj1995/GPT-SoVITS) 에서 사전 학습된 모델을 다운로드하고, `GPT_SoVITS/pretrained_models` 디렉토리에 배치하세요.
 

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -153,7 +153,7 @@ docker run --rm -it --gpus=all --env=is_half=False --volume=G:\GPT-SoVITS-Docker
 
 3. UVR5 (보컬/반주 분리 & 잔향 제거 추가 기능)의 경우, [UVR5 Weights](https://huggingface.co/lj1995/VoiceConversionWebUI/tree/main/uvr5_weights) 에서 모델을 다운로드하고 `tools/uvr5/uvr5_weights` 디렉토리에 배치하세요.
 
-   - UVR5에서 bs_roformer 또는 mel_band_roformer 모델을 사용할 경우, 모델과 해당 설정 파일을 수동으로 다운로드하여 `tools/UVR5/UVR5_weights` 폴더에 저장할 수 있습니다. **모델 파일과 설정 파일의 이름은 확장자를 제외하고 동일한 이름을 가지도록 해야 합니다**. 또한, 모델과 설정 파일 이름에는 **“roformer”**가 포함되어야 roformer 클래스의 모델로 인식됩니다.
+   - UVR5에서 bs_roformer 또는 mel_band_roformer 모델을 사용할 경우, 모델과 해당 설정 파일을 수동으로 다운로드하여 `tools/UVR5/UVR5_weights` 폴더에 저장할 수 있습니다. **모델 파일과 설정 파일의 이름은 확장자를 제외하고 동일한 이름을 가지도록 해야 합니다**. 또한, 모델과 설정 파일 이름에는 **"roformer"**가 포함되어야 roformer 클래스의 모델로 인식됩니다.
 
    - 모델 이름과 설정 파일 이름에 **모델 유형을 직접 지정하는 것이 좋습니다**. 예: mel_mand_roformer, bs_roformer. 지정하지 않으면 설정 파일을 기준으로 특성을 비교하여 어떤 유형의 모델인지를 판단합니다. 예를 들어, 모델 `bs_roformer_ep_368_sdr_12.9628.ckpt`와 해당 설정 파일 `bs_roformer_ep_368_sdr_12.9628.yaml`은 한 쌍입니다. `kim_mel_band_roformer.ckpt`와 `kim_mel_band_roformer.yaml`도 한 쌍입니다.
 

--- a/docs/tr/README.md
+++ b/docs/tr/README.md
@@ -42,12 +42,14 @@ https://github.com/RVC-Boss/GPT-SoVITS/assets/129054828/05bee1fa-bdd8-4d85-9350-
 
 ### Test Edilmiş Ortamlar
 
-- Python 3.9, PyTorch 2.0.1, CUDA 11
-- Python 3.10.13, PyTorch 2.1.2, CUDA 12.3
-- Python 3.9, PyTorch 2.2.2, macOS 14.4.1 (Apple silikon)
-- Python 3.9, PyTorch 2.2.2, CPU cihazları
-
-_Not: numba==0.56.4, py<3.11 gerektirir_
+| Python Version | PyTorch Version  | Device          |
+|----------------|------------------|-----------------|
+| Python 3.9     | PyTorch 2.0.1    | CUDA 11.8       |
+| Python 3.10.13 | PyTorch 2.1.2    | CUDA 12.3       |
+| Python 3.10.17 | PyTorch 2.5.1    | CUDA 12.4       |
+| Python 3.9     | PyTorch 2.5.1    | Apple silicon   |
+| Python 3.11    | PyTorch 2.6.0    | Apple silicon   |
+| Python 3.9     | PyTorch 2.2.2    | CPU             |
 
 ### Windows
 
@@ -115,10 +117,10 @@ pip install -r requirements.txt
 
 #### docker-compose.yaml yapılandırması
 
-0. Görüntü etiketleri hakkında: Kod tabanındaki hızlı güncellemeler ve görüntüleri paketleme ve test etme işleminin yavaş olması nedeniyle, lütfen şu anda paketlenmiş en son görüntüleri kontrol etmek için [Docker Hub](https://hub.docker.com/r/breakstring/gpt-sovits) adresini kontrol edin ve durumunuza göre seçim yapın veya alternatif olarak, kendi ihtiyaçlarınıza göre bir Dockerfile kullanarak yerel olarak oluşturun.
+0. Görüntü etiketleri hakkında: Kod tabanındaki hızlı güncellemeler ve görüntüleri paketleme ve test etme işleminin yavaş olması nedeniyle, lütfen şu anda paketlenmiş en son görüntüleri kontrol etmek için [Docker Hub](https://hub.docker.com/r/breakstring/gpt-sovits)(eski sürüm) adresini kontrol edin ve durumunuza göre seçim yapın veya alternatif olarak, kendi ihtiyaçlarınıza göre bir Dockerfile kullanarak yerel olarak oluşturun.
 1. Ortam Değişkenleri：
    - is_half: Yarım hassasiyet/çift hassasiyeti kontrol eder. Bu genellikle "SSL çıkarma" adımı sırasında 4-cnhubert/5-wav32k dizinleri altındaki içeriğin doğru şekilde oluşturulmamasının nedenidir. Gerçek durumunuza göre True veya False olarak ayarlayın.
-2. Birim Yapılandırması，Kapsayıcı içindeki uygulamanın kök dizini /workspace olarak ayarlanmıştır. Varsayılan docker-compose.yaml, içerik yükleme/indirme için bazı pratik örnekler listeler.
+2. Birim Yapılandırması, Kapsayıcı içindeki uygulamanın kök dizini /workspace olarak ayarlanmıştır. Varsayılan docker-compose.yaml, içerik yükleme/indirme için bazı pratik örnekler listeler.
 3. shm_size： Windows üzerinde Docker Desktop için varsayılan kullanılabilir bellek çok küçüktür, bu da anormal işlemlere neden olabilir. Kendi durumunuza göre ayarlayın.
 4. Dağıtım bölümü altında, GPU ile ilgili ayarlar sisteminize ve gerçek koşullara göre dikkatlice ayarlanmalıdır.
 
@@ -137,6 +139,8 @@ docker run --rm -it --gpus=all --env=is_half=False --volume=G:\GPT-SoVITS-Docker
 ```
 
 ## Önceden Eğitilmiş Modeller
+
+**Eğer `install.sh` başarıyla çalıştırılırsa, No.1 adımını atlayabilirsiniz.**
 
 1. [GPT-SoVITS Models](https://huggingface.co/lj1995/GPT-SoVITS) üzerinden önceden eğitilmiş modelleri indirip `GPT_SoVITS/pretrained_models` dizinine yerleştirin.
 

--- a/docs/tr/README.md
+++ b/docs/tr/README.md
@@ -118,10 +118,10 @@ pip install -r requirements.txt
 #### docker-compose.yaml yapılandırması
 
 0. Görüntü etiketleri hakkında: Kod tabanındaki hızlı güncellemeler ve görüntüleri paketleme ve test etme işleminin yavaş olması nedeniyle, lütfen şu anda paketlenmiş en son görüntüleri kontrol etmek için [Docker Hub](https://hub.docker.com/r/breakstring/gpt-sovits)(eski sürüm) adresini kontrol edin ve durumunuza göre seçim yapın veya alternatif olarak, kendi ihtiyaçlarınıza göre bir Dockerfile kullanarak yerel olarak oluşturun.
-1. Ortam Değişkenleri：
+1. Ortam Değişkenleri: 
    - is_half: Yarım hassasiyet/çift hassasiyeti kontrol eder. Bu genellikle "SSL çıkarma" adımı sırasında 4-cnhubert/5-wav32k dizinleri altındaki içeriğin doğru şekilde oluşturulmamasının nedenidir. Gerçek durumunuza göre True veya False olarak ayarlayın.
 2. Birim Yapılandırması, Kapsayıcı içindeki uygulamanın kök dizini /workspace olarak ayarlanmıştır. Varsayılan docker-compose.yaml, içerik yükleme/indirme için bazı pratik örnekler listeler.
-3. shm_size： Windows üzerinde Docker Desktop için varsayılan kullanılabilir bellek çok küçüktür, bu da anormal işlemlere neden olabilir. Kendi durumunuza göre ayarlayın.
+3. shm_size: Windows üzerinde Docker Desktop için varsayılan kullanılabilir bellek çok küçüktür, bu da anormal işlemlere neden olabilir. Kendi durumunuza göre ayarlayın.
 4. Dağıtım bölümü altında, GPU ile ilgili ayarlar sisteminize ve gerçek koşullara göre dikkatlice ayarlanmalıdır.
 
 #### docker compose ile çalıştırma
@@ -148,7 +148,7 @@ docker run --rm -it --gpus=all --env=is_half=False --volume=G:\GPT-SoVITS-Docker
 
 3. UVR5 (Vokal/Enstrümantal Ayrımı & Yankı Giderme) için, [UVR5 Weights](https://huggingface.co/lj1995/VoiceConversionWebUI/tree/main/uvr5_weights) üzerinden modelleri indirip `tools/uvr5/uvr5_weights` dizinine yerleştirin.
 
-   - UVR5'te bs_roformer veya mel_band_roformer modellerini kullanıyorsanız, modeli ve ilgili yapılandırma dosyasını manuel olarak indirip `tools/UVR5/UVR5_weights` klasörüne yerleştirebilirsiniz. **Model dosyası ve yapılandırma dosyasının adı, uzantı dışında aynı olmalıdır**. Ayrıca, model ve yapılandırma dosyasının adlarında **“roformer”** kelimesi yer almalıdır, böylece roformer sınıfındaki bir model olarak tanınır.
+   - UVR5'te bs_roformer veya mel_band_roformer modellerini kullanıyorsanız, modeli ve ilgili yapılandırma dosyasını manuel olarak indirip `tools/UVR5/UVR5_weights` klasörüne yerleştirebilirsiniz. **Model dosyası ve yapılandırma dosyasının adı, uzantı dışında aynı olmalıdır**. Ayrıca, model ve yapılandırma dosyasının adlarında **"roformer"** kelimesi yer almalıdır, böylece roformer sınıfındaki bir model olarak tanınır.
 
    - Model adı ve yapılandırma dosyası adı içinde **doğrudan model tipini belirtmek önerilir**. Örneğin: mel_mand_roformer, bs_roformer. Belirtilmezse, yapılandırma dosyasından özellikler karşılaştırılarak model tipi belirlenir. Örneğin, `bs_roformer_ep_368_sdr_12.9628.ckpt` modeli ve karşılık gelen yapılandırma dosyası `bs_roformer_ep_368_sdr_12.9628.yaml` bir çifttir. Aynı şekilde, `kim_mel_band_roformer.ckpt` ve `kim_mel_band_roformer.yaml` da bir çifttir.
 
@@ -270,7 +270,7 @@ V1 ortamından V2'yi kullanmak için:
 
 1. `pip install -r requirements.txt` ile bazı paketleri güncelleyin.
 
-2. GitHub’dan en son kodları klonlayın.
+2. GitHub'dan en son kodları klonlayın.
 
 3. [huggingface](https://huggingface.co/lj1995/GPT-SoVITS/tree/main) üzerinden v3 önceden eğitilmiş modellerini (s1v3.ckpt, s2Gv3.pth ve models--nvidia--bigvgan_v2_24khz_100band_256x klasörünü) indirin ve `GPT_SoVITS\pretrained_models` dizinine yerleştirin.
 
@@ -378,7 +378,7 @@ python ./tools/asr/fasterwhisper_asr.py -i <girdi> -o <çıktı> -l <dil>
 - [FunASR](https://github.com/alibaba-damo-academy/FunASR)
 - [AP-BWE](https://github.com/yxlu-0102/AP-BWE)
 
-@Naozumi520’ye Kantonca eğitim setini sağladığı ve Kantonca ile ilgili bilgiler konusunda rehberlik ettiği için minnettarım.
+@Naozumi520'ye Kantonca eğitim setini sağladığı ve Kantonca ile ilgili bilgiler konusunda rehberlik ettiği için minnettarım.
 
 ## Tüm katkıda bulunanlara çabaları için teşekkürler
 

--- a/go-webui.bat
+++ b/go-webui.bat
@@ -1,2 +1,2 @@
-runtime\python.exe webui.py zh_CN
+runtime\python.exe -I webui.py zh_CN
 pause

--- a/go-webui.ps1
+++ b/go-webui.ps1
@@ -1,4 +1,4 @@
 $ErrorActionPreference = "SilentlyContinue"
 chcp 65001
-& "$PSScriptRoot\runtime\python.exe" "$PSScriptRoot\webui.py" zh_CN
+& "$PSScriptRoot\runtime\python.exe" -I "$PSScriptRoot\webui.py" zh_CN
 pause

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
+# cd into GPT-SoVITS Base Path
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+cd "$SCRIPT_DIR" || exit 1
+
 set -e
+
+trap 'echo "Error Occured at \"$BASH_COMMAND\" with exit code $?"; exit 1' ERR
 
 # 安装构建工具
 # Install build tools
@@ -12,6 +19,47 @@ conda install -c conda-forge gxx -y
 
 echo "Installing ffmpeg and cmake..."
 conda install ffmpeg cmake -y
+
+echo "Installing git-lfs and zip..."
+conda install git-lfs -y
+conda apt install zip -y
+
+git-lfs install
+
+# Download Pretrained Models
+if find "GPT_SoVITS/pretrained_models" -mindepth 1 ! -name '.gitignore' | grep -q .; then
+    echo "Pretrained Model Exists"
+else
+    echo "Download Pretrained Models"
+    wget --tries=25 --wait=5 --read-timeout=40 --retry-on-http-error=404 "https://www.modelscope.cn/models/XXXXRT/GPT-SoVITS-Pretrained/resolve/master/pretrained_models.zip"
+
+    unzip pretrained_models.zip
+    rm -rf pretrained_models.zip
+    mv pretrained_models/* GPT_SoVITS/pretrained_models
+    rm -rf pretrained_models
+fi
+
+# Download G2PW Models
+if [ ! -d "GPT_SoVITS/text/G2PWModel" ]; then
+    echo "Download G2PWModel"
+    wget --tries=25 --wait=5 --read-timeout=40 --retry-on-http-error=404 "https://www.modelscope.cn/models/kamiorinn/g2pw/resolve/master/G2PWModel_1.1.zip"
+
+    unzip G2PWModel_1.1.zip
+    rm -rf G2PWModel_1.1.zip
+    mv G2PWModel_1.1 GPT_SoVITS/text/G2PWModel
+else
+    echo "G2PWModel Exists"
+fi
+
+if [ ! -d "GPT_SoVITS/pretrained_models/fast_langdetect" ]; then
+    echo "Download Fast Langdetect Model"
+    wget --tries=25 --wait=5 --read-timeout=40 --retry-on-http-error=404 "https://dl.fbaipublicfiles.com/fasttext/supervised-models/lid.176.bin"
+
+    mkdir "GPT_SoVITS/pretrained_models/fast_langdetect"
+    mv "lid.176.bin" "GPT_SoVITS/pretrained_models/fast_langdetect"
+else
+    echo "Fast Langdetect Model Exists"
+fi
 
 # 设置编译环境
 # Set up build environment
@@ -62,37 +110,6 @@ echo "Installing Python dependencies from requirements.txt..."
 # 刷新环境
 # Refresh environment
 hash -r
-
-# pyopenjtalk Installation
-conda install jq -y
-
-OS_TYPE=$(uname)
-
-PACKAGE_NAME="pyopenjtalk"
-
-VERSION=$(curl -s https://pypi.org/pypi/$PACKAGE_NAME/json | jq -r .info.version)
-
-wget "https://files.pythonhosted.org/packages/source/${PACKAGE_NAME:0:1}/$PACKAGE_NAME/$PACKAGE_NAME-$VERSION.tar.gz"
-
-TAR_FILE=$(ls ${PACKAGE_NAME}-*.tar.gz)
-DIR_NAME="${TAR_FILE%.tar.gz}"
-
-tar -xzf "$TAR_FILE"
-rm "$TAR_FILE"
-
-CMAKE_FILE="$DIR_NAME/lib/open_jtalk/src/CMakeLists.txt"
-
-if [[ "$OS_TYPE" == "darwin"* ]]; then
-    sed -i '' -E 's/cmake_minimum_required\(VERSION[^\)]*\)/cmake_minimum_required(VERSION 3.5...3.31)/' "$CMAKE_FILE"
-else
-    sed -i -E 's/cmake_minimum_required\(VERSION[^\)]*\)/cmake_minimum_required(VERSION 3.5...3.31)/' "$CMAKE_FILE"
-fi
-
-tar -czf "$TAR_FILE" "$DIR_NAME"
-
-pip install "$TAR_FILE"
-
-rm -rf "$TAR_FILE" "$DIR_NAME"
 
 pip install -r extra-req.txt --no-deps
 

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@ conda install ffmpeg cmake -y
 
 echo "Installing git-lfs and zip..."
 conda install git-lfs -y
-conda apt install zip -y
+conda install zip -y
 
 git-lfs install
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-numpy==1.23.4
+numpy<2.0
 scipy
 tensorboard
 librosa==0.9.2
-numba==0.56.4
-pytorch-lightning>2.0
-gradio>=4.0,<=4.24.0
+numba
+pytorch-lightning>=2.4
+gradio<5
 ffmpeg-python
 onnxruntime; sys_platform == 'darwin'
 onnxruntime-gpu; sys_platform != 'darwin'
@@ -12,7 +12,7 @@ tqdm
 funasr==1.0.27
 cn2an
 pypinyin
-pyopenjtalk>=0.3.4
+pyopenjtalk>=0.4.1
 g2p_en
 torchaudio
 modelscope==1.10.0
@@ -25,7 +25,7 @@ psutil
 jieba_fast
 jieba
 split-lang
-fast_langdetect>=0.3.0
+fast_langdetect>=0.3.1
 wordsegment
 rotary_embedding_torch
 ToJyutping 
@@ -34,7 +34,7 @@ ko_pron
 opencc; sys_platform != 'linux'
 opencc==1.1.1; sys_platform == 'linux'
 python_mecab_ko; sys_platform != 'win32'
-fastapi<0.112.2
+fastapi>=0.115.1
 x_transformers
 torchmetrics<=1.5
 pydantic<=2.10.6


### PR DESCRIPTION
1. Updated requirements to support Python 3.11
2. Replace full-width punctuation in docs with half-width
3. Add more tested environments
4. Update Colab notebook
5. Add pretrained model download to install.sh