### PR TITLE
修复#2354并新增本地模式配置

### DIFF
--- a/GPT_SoVITS/TTS_infer_pack/TTS.py
+++ b/GPT_SoVITS/TTS_infer_pack/TTS.py
@@ -468,7 +468,7 @@ class TTS:
         version, model_version, if_lora_v3 = get_sovits_version_from_path_fast(weights_path)
         path_sovits = self.configs.default_configs[model_version]["vits_weights_path"]
 
-        if if_lora_v3 == True and os.path.exists(path_sovits) == False:
+        if model_version in {"v3", "v4"} and os.path.exists(path_sovits) == False:
             info = path_sovits + i18n("SoVITS %s 底模缺失，无法加载相应 LoRA 权重"%model_version)
             raise FileExistsError(info)
 
@@ -520,7 +520,7 @@ class TTS:
             if "pretrained" not in weights_path and hasattr(vits_model, "enc_q"):
                 del vits_model.enc_q
 
-        if if_lora_v3 == False:
+        if model_version not in {"v3", "v4"}:
             print(
                 f"Loading VITS weights from {weights_path}. {vits_model.load_state_dict(dict_s2['weight'], strict=False)}"
             )
@@ -614,9 +614,6 @@ class TTS:
             self.vocoder_configs["T_chunk"] = 1000
             self.vocoder_configs["upsample_rate"] = 480
             self.vocoder_configs["overlapped_len"] = 12
-
-
-
 
         self.vocoder = self.vocoder.eval()
         if self.configs.is_half == True:
@@ -1257,7 +1254,7 @@ class TTS:
                         speed_factor,
                         False,
                         fragment_interval,
-                        super_sampling if self.configs.use_vocoder and self.configs.version == "v3" else False,
+                        super_sampling if self.configs.use_vocoder and self.configs.version in {"v3", "v4"} else False,
                     )
                 else:
                     audio.append(batch_audio_fragment)
@@ -1278,7 +1275,7 @@ class TTS:
                     speed_factor,
                     split_bucket,
                     fragment_interval,
-                    super_sampling if self.configs.use_vocoder and self.configs.version == "v3" else False,
+                    super_sampling if self.configs.use_vocoder and self.configs.version in {"v3", "v4"} else False,
                 )
 
         except Exception as e:

--- a/GPT_SoVITS/TTS_infer_pack/TTS.py
+++ b/GPT_SoVITS/TTS_infer_pack/TTS.py
@@ -287,8 +287,9 @@ class TTS_Config:
             configs: dict = self._load_configs(self.configs_path)
 
         assert isinstance(configs, dict)
-        version = configs.get("version", "v2").lower()
-        assert version in ["v1", "v2", "v3", "v4"]
+        version = "v2"
+        if "custom" in configs and configs["custom"]["version"].lower() in ["v1", "v2", "v3", "v4"]:
+            version = configs["custom"]["version"].lower()
         self.default_configs[version] = configs.get(version, self.default_configs[version])
         self.configs: dict = configs.get("custom", deepcopy(self.default_configs[version]))
 

--- a/GPT_SoVITS/inference_webui.py
+++ b/GPT_SoVITS/inference_webui.py
@@ -91,6 +91,8 @@ infer_ttswebui = os.environ.get("infer_ttswebui", 9872)
 infer_ttswebui = int(infer_ttswebui)
 is_share = os.environ.get("is_share", "False")
 is_share = eval(is_share)
+local_mode = os.environ.get("local_mode", "False")
+local_mode = eval(local_mode)
 if "_CUDA_VISIBLE_DEVICES" in os.environ:
     os.environ["CUDA_VISIBLE_DEVICES"] = os.environ["_CUDA_VISIBLE_DEVICES"]
 is_half = eval(os.environ.get("is_half", "True")) and torch.cuda.is_available()
@@ -1273,7 +1275,7 @@ with gr.Blocks(title="GPT-SoVITS WebUI") as app:
 
 if __name__ == "__main__":
     app.queue().launch(  # concurrency_count=511, max_size=1022
-        server_name="0.0.0.0",
+        server_name="127.0.0.1" if local_mode else "0.0.0.0",
         inbrowser=True,
         share=is_share,
         server_port=infer_ttswebui,

--- a/config.py
+++ b/config.py
@@ -30,6 +30,9 @@ webui_port_subfix = 9871
 
 api_port = 9880
 
+# 设置为True可启用本地模式，该模式只允许本机访问，避免出现潜在安全问题。默认为False。
+local_mode = False
+
 if infer_device == "cuda":
     gpu_name = torch.cuda.get_device_name(0)
     if (

--- a/tools/subfix_webui.py
+++ b/tools/subfix_webui.py
@@ -298,6 +298,7 @@ if __name__ == "__main__":
     parser.add_argument("--json_key_text", default="text", help="the text key name in json, Default: text")
     parser.add_argument("--json_key_path", default="wav_path", help="the path key name in json, Default: wav_path")
     parser.add_argument("--g_batch", default=10, help="max number g_batch wav to display, Default: 10")
+    parser.add_argument("--local_mode", action="store_true", help="enable local mode (bind to 127.0.0.1)")
 
     args = parser.parse_args()
 
@@ -407,7 +408,7 @@ if __name__ == "__main__":
         )
 
     demo.launch(
-        server_name="0.0.0.0",
+        server_name="127.0.0.1" if args.local_mode else "0.0.0.0",
         inbrowser=True,
         # quiet=True,
         share=eval(args.is_share),

--- a/tools/uvr5/webui.py
+++ b/tools/uvr5/webui.py
@@ -32,6 +32,7 @@ device = sys.argv[1]
 is_half = eval(sys.argv[2])
 webui_port_uvr5 = int(sys.argv[3])
 is_share = eval(sys.argv[4])
+local_mode = sys.argv[5].lower() == 'true' if len(sys.argv) > 5 else False
 
 
 def html_left(text, label="p"):
@@ -220,7 +221,7 @@ with gr.Blocks(title="UVR5 WebUI") as app:
                     api_name="uvr_convert",
                 )
 app.queue().launch(  # concurrency_count=511, max_size=1022
-    server_name="0.0.0.0",
+    server_name="127.0.0.1" if local_mode else "0.0.0.0",
     inbrowser=True,
     share=is_share,
     server_port=webui_port_uvr5,

--- a/webui.py
+++ b/webui.py
@@ -74,6 +74,7 @@ from config import (
     webui_port_main,
     webui_port_subfix,
     webui_port_uvr5,
+    local_mode,
 )
 from tools import my_utils
 from tools.i18n.i18n import I18nAuto, scan_language_list
@@ -1955,7 +1956,7 @@ with gr.Blocks(title="GPT-SoVITS WebUI") as app:
             gr.Markdown(value=i18n("施工中，请静候佳音"))
 
     app.queue().launch(  # concurrency_count=511, max_size=1022
-        server_name="0.0.0.0",
+        server_name="127.0.0.1" if local_mode else "0.0.0.0",
         inbrowser=True,
         share=is_share,
         server_port=webui_port_main,

--- a/webui.py
+++ b/webui.py
@@ -389,6 +389,8 @@ def change_label(path_list):
             webui_port_subfix,
             is_share,
         )
+        if local_mode:
+            cmd += " --local_mode"
         yield (
             process_info(process_name_subfix, "opened"),
             {"__type__": "update", "visible": False},
@@ -413,6 +415,8 @@ def change_uvr5():
     global p_uvr5
     if p_uvr5 is None:
         cmd = '"%s" tools/uvr5/webui.py "%s" %s %s %s' % (python_exec, infer_device, is_half, webui_port_uvr5, is_share)
+        if local_mode:
+            cmd += " True"
         yield (
             process_info(process_name_uvr5, "opened"),
             {"__type__": "update", "visible": False},
@@ -451,6 +455,7 @@ def change_tts_inference(bert_path, cnhubert_base_path, gpu_number, gpt_path, so
         os.environ["is_half"] = str(is_half)
         os.environ["infer_ttswebui"] = str(webui_port_infer_tts)
         os.environ["is_share"] = str(is_share)
+        os.environ["local_mode"] = str(local_mode)
         yield (
             process_info(process_name_tts, "opened"),
             {"__type__": "update", "visible": False},


### PR DESCRIPTION
## 错误修复
修复了[#2354](https://github.com/RVC-Boss/GPT-SoVITS/issues/2354)里启动API时v4模型被识别成v2的问题。  
现在`api.py`和`api_v2.py`都可以正常兼容v4的模型。

问题出在：  
1. 由于`GPT_SoVITS/configs/tts_infer.yaml`中缺少`version`字段，导致version永远被设置为“v2”。
2. `api.py`中缺少对“v4”的判断。

## 功能新增
在`config.py`里新增`local_mode`本地模式开关，默认关闭，启用后服务仅限本机访问（`127.0.0.1`或`localhost`）。  

这样做的好处是：  
1. 为开发调试场景提供更安全的本地隔离选项。  
2. 避免在敏感场景下意外暴露服务到局域网或公网。  

## 兼容性说明
- 完全兼容现有部署方式。 
- 不影响原有行为。