### PR TITLE
修复 V4 版本模型 API 调用出错的问题，但本质仍是作为 V3 模型使用

### DIFF
--- a/api.py
+++ b/api.py
@@ -313,9 +313,11 @@ def get_sovits_weights(sovits_path):
 
     if model_version == "v3":
         hps.model.version = "v3"
+    if model_version == "v4":
+        hps.model.version = "v4"
 
     model_params_dict = vars(hps.model)
-    if model_version != "v3":
+    if model_version != "v3" and model_version != "v4":
         vq_model = SynthesizerTrn(
             hps.data.filter_length // 2 + 1,
             hps.train.segment_size // hps.data.hop_length,
@@ -759,7 +761,7 @@ def get_tts_wav(
         prompt_semantic = codes[0, 0]
         prompt = prompt_semantic.unsqueeze(0).to(device)
 
-        if version != "v3":
+        if version != "v3" and version != "v4":
             refers = []
             if inp_refs:
                 for path in inp_refs:
@@ -811,7 +813,7 @@ def get_tts_wav(
             pred_semantic = pred_semantic[:, -idx:].unsqueeze(0)
         t3 = ttime()
 
-        if version != "v3":
+        if version != "v3" and version != "v4":
             audio = (
                 vq_model.decode(pred_semantic, torch.LongTensor(phones2).to(device).unsqueeze(0), refers, speed=speed)
                 .detach()


### PR DESCRIPTION
当在 config.py 中写入 V4 版本模型地址后，运行 api.py 并访问 URL 后会报错，查看后发现没有判断模型版本的语句，导致 speaker_list 为空字典，debug 过程和修复过程在视频里了，虽然本质仍是作为 V3 模型使用，但不报错了
视频：https://www.bilibili.com/video/BV12R7gzTEuz