### PR TITLE
Fix mirror errors when running inference webui directly

### DIFF
--- a/config.py
+++ b/config.py
@@ -4,7 +4,7 @@ import os
 import torch,re
 
 from tools.i18n.i18n import I18nAuto, scan_language_list
-i18n = I18nAuto(language=os.environ["language"])
+i18n = I18nAuto(language=os.environ.get("language", "Auto"))
 
 
 pretrained_sovits_name = {
@@ -67,6 +67,7 @@ def get_weights_names():
     for key in name2sovits_path:
         if os.path.exists(name2sovits_path[key]):SoVITS_names.append(key)
     for path in SoVITS_weight_root:
+        if not os.path.exists(path):continue
         for name in os.listdir(path):
             if name.endswith(".pth"):
                 SoVITS_names.append("%s/%s" % (path, name))
@@ -74,6 +75,7 @@ def get_weights_names():
     for key in name2gpt_path:
         if os.path.exists(name2gpt_path[key]):GPT_names.append(key)
     for path in GPT_weight_root:
+        if not os.path.exists(path):continue
         for name in os.listdir(path):
             if name.endswith(".ckpt"):
                 GPT_names.append("%s/%s" % (path, name))


### PR DESCRIPTION
直接运行 `inference_webui.py` 时，`config.py` 文件中会出现错误：
- 环境变量 os.environ["language"] 不存在时，取默认值 "Auto"
- 预定义的 SoVITS_weight_root 和 GPT_weight_root 列表内的元素为文件夹路径，当文件夹路径不存在时进行跳过处理。