### PR TITLE
Fix AttributeError: 'tuple' object has no attribute 'to' in using_vocoder_synthesis_batched_infer

### DIFF
--- a/GPT_SoVITS/TTS_infer_pack/TTS.py
+++ b/GPT_SoVITS/TTS_infer_pack/TTS.py
@@ -1407,7 +1407,10 @@ class TTS:
     ):
         prompt_semantic_tokens = self.prompt_cache["prompt_semantic"].unsqueeze(0).unsqueeze(0).to(self.configs.device)
         prompt_phones = torch.LongTensor(self.prompt_cache["phones"]).unsqueeze(0).to(self.configs.device)
-        refer_audio_spec = self.prompt_cache["refer_spec"][0].to(dtype=self.precision, device=self.configs.device)
+        raw_entry = self.prompt_cache["refer_spec"][0]
+        if isinstance(raw_entry, tuple):
+            raw_entry = raw_entry[0]
+        refer_audio_spec = raw_entry.to(dtype=self.precision,device=self.configs.device)
 
         fea_ref, ge = self.vits_model.decode_encp(prompt_semantic_tokens, prompt_phones, refer_audio_spec)
         ref_audio: torch.Tensor = self.prompt_cache["raw_audio"]
@@ -1474,7 +1477,10 @@ class TTS:
     ) -> List[torch.Tensor]:
         prompt_semantic_tokens = self.prompt_cache["prompt_semantic"].unsqueeze(0).unsqueeze(0).to(self.configs.device)
         prompt_phones = torch.LongTensor(self.prompt_cache["phones"]).unsqueeze(0).to(self.configs.device)
-        refer_audio_spec = self.prompt_cache["refer_spec"][0].to(dtype=self.precision, device=self.configs.device)
+        raw_entry = self.prompt_cache["refer_spec"][0]
+        if isinstance(raw_entry, tuple):
+            raw_entry = raw_entry[0]
+        refer_audio_spec = raw_entry.to(dtype=self.precision,device=self.configs.device)
 
         fea_ref, ge = self.vits_model.decode_encp(prompt_semantic_tokens, prompt_phones, refer_audio_spec)
         ref_audio: torch.Tensor = self.prompt_cache["raw_audio"]


### PR DESCRIPTION
#### What does this PR do?

* Gracefully handles the case where `self.prompt_cache["refer_spec"][0]` is a **tuple** instead of a `torch.Tensor`.
* Keeps backward compatibility for the original tensor-only path.

```python
raw_entry = self.prompt_cache["refer_spec"][0]
if isinstance(raw_entry, tuple):     # NEW ── unwrap the tuple
    raw_entry = raw_entry[0]

refer_audio_spec = raw_entry.to(dtype=self.precision,
                                device=self.configs.device)
```

#### Why is it needed? — Error & context

```text
Traceback (most recent call last):
  File ".../TTS_infer_pack/TTS.py", line 1477, in using_vocoder_synthesis_batched_infer
    refer_audio_spec = self.prompt_cache["refer_spec"][0].to(dtype=self.precision, device=self.configs.device)
AttributeError: 'tuple' object has no attribute 'to'
```

`self._get_ref_spec()` currently returns `(spec_tensor, audio_tensor)`.
When that tuple is cached unchanged, the downstream vocoder code assumes it is a plain
tensor and calls `.to()`, causing the exception above.
