### PR TITLE
修复了部分显卡无法正确识别的问题

### DIFF
--- a/config.py
+++ b/config.py
@@ -158,13 +158,14 @@ def get_device_dtype_sm(idx: int) -> tuple[torch.device, torch.dtype, float, flo
     major, minor = capability
     sm_version = major + minor / 10.0
     is_16_series = bool(re.search(r"16\d{2}", name))
-    if mem_gb < 4:
+    if mem_gb < 4 or sm_version < 5.3:
         return cpu, torch.float32, 0.0, 0.0
-    if (sm_version >= 7.0 and sm_version != 7.5) or (5.3 <= sm_version <= 6.0):
-        if is_16_series and sm_version == 7.5:
-            return cuda, torch.float32, sm_version, mem_gb  # 16系卡除外
-        else:
-            return cuda, torch.float16, sm_version, mem_gb
+    if sm_version < 6.0:
+        return cuda, torch.float32, sm_version, mem_gb
+    if is_16_series and sm_version == 7.5: # 16系列不使用float16
+        return cuda, torch.float32, sm_version, mem_gb
+    if sm_version >= 7.0:
+        return cuda, torch.float16, sm_version, mem_gb
     return cpu, torch.float32, 0.0, 0.0
 
 


### PR DESCRIPTION
优化了config.py中对于显卡的判断逻辑。原本的判断逻辑会导致2080Ti无法被正确识别。

## 新的判断逻辑
```mermaid
flowchart TD
    A{CUDA 可用?} -->|否| B[返回 CPU + float32]
    A -->|是| C[获取设备属性：SM版本、显存、型号]
    C --> D{显存 < 4GB 或 SM < 5.3?}
    D -->|是| E[返回 CPU + float32]
    D -->|否| F{SM < 6.0?}
    F -->|是| G[返回 CUDA + float32]
    F -->|否| H{型号是16xxx且SM == 7.5?}
    H -->|是| I[返回 CUDA + float32]
    H -->|否| J{SM >= 7.0?}
    J -->|是| K[返回 CUDA + float16]
    J -->|否| L[返回 CPU + float32]
```

## 原始错误
2080Ti会被错误判断为CPU：
![屏幕截图 2025-06-05 165103](https://github.com/user-attachments/assets/03eb5d0c-1c28-4fa8-ac2a-e1fbb6c01e66)
![屏幕截图 2025-06-05 165047](https://github.com/user-attachments/assets/aa8e9965-6a2e-47c0-bcb8-0a63fcce7175)