### PR TITLE
fix _merge_yi crash

### DIFF
--- a/GPT_SoVITS/text/tone_sandhi.py
+++ b/GPT_SoVITS/text/tone_sandhi.py
@@ -654,18 +654,19 @@ class ToneSandhi:
         # function 1
         while i < len(seg):
             word, pos = seg[i]
+            merged = False
             if (
                 i - 1 >= 0
                 and word == "一"
                 and i + 1 < len(seg)
-                and seg[i - 1][0] == seg[i + 1][0]
-                and seg[i - 1][1] == "v"
-                and seg[i + 1][1] == "v"
             ):
-                merged = seg[i - 1][0] + "一" + seg[i + 1][0]
-                new_seg[-1] = [merged, seg[i - 1][1]]
-                i += 2
-            else:
+                last = new_seg[-1] if new_seg else seg[i - 1]
+                if last[0] == seg[i + 1][0] and last[1] == "v" and seg[i + 1][1] == "v":
+                    combined = last[0] + "一" + seg[i + 1][0]
+                    new_seg[-1] = [combined, last[1]]
+                    i += 2
+                    merged = True
+            if not merged:
                 new_seg.append([word, pos])
                 i += 1
         seg = new_seg

--- a/GPT_SoVITS/text/tone_sandhi.py
+++ b/GPT_SoVITS/text/tone_sandhi.py
@@ -650,8 +650,10 @@ class ToneSandhi:
     # output seg: [['听一听', 'v']]
     def _merge_yi(self, seg: List[Tuple[str, str]]) -> List[Tuple[str, str]]:
         new_seg = []
+        i = 0
         # function 1
-        for i, (word, pos) in enumerate(seg):
+        while i < len(seg):
+            word, pos = seg[i]
             if (
                 i - 1 >= 0
                 and word == "一"
@@ -660,22 +662,16 @@ class ToneSandhi:
                 and seg[i - 1][1] == "v"
                 and seg[i + 1][1] == "v"
             ):
-                new_seg[i - 1][0] = new_seg[i - 1][0] + "一" + new_seg[i - 1][0]
+                merged = seg[i - 1][0] + "一" + seg[i + 1][0]
+                new_seg[-1] = [merged, seg[i - 1][1]]
+                i += 2
             else:
-                if (
-                    i - 2 >= 0
-                    and seg[i - 1][0] == "一"
-                    and seg[i - 2][0] == word
-                    and pos == "v"
-                    and seg[i - 2][1] == "v"
-                ):
-                    continue
-                else:
-                    new_seg.append([word, pos])
+                new_seg.append([word, pos])
+                i += 1
         seg = new_seg
         new_seg = []
         # function 2
-        for i, (word, pos) in enumerate(seg):
+        for word, pos in seg:
             if new_seg and new_seg[-1][0] == "一":
                 new_seg[-1][0] = new_seg[-1][0] + word
             else:


### PR DESCRIPTION
当前逻辑会在处理下述有多个"X一X"的pattern时由于索引越界崩溃，如：
[['一起来', 'm'], ['听一听', 'v'], ['唱一唱', 'v'], ['吧', 'y'], [',', 'x']]