### PR TITLE
修复if self.is_half==True:wav=wav.half() AttributeError: 'NoneType' object has no attribute 'half'

### DIFF
--- a/GPT_SoVITS/TTS_infer_pack/TTS.py
+++ b/GPT_SoVITS/TTS_infer_pack/TTS.py
@@ -1073,7 +1073,7 @@ class TTS:
 
         ###### setting reference audio and prompt text preprocessing ########
         t0 = time.perf_counter()
-        if (ref_audio_path is not None) and (ref_audio_path != self.prompt_cache["ref_audio_path"]):
+        if (ref_audio_path is not None) and (ref_audio_path != self.prompt_cache["ref_audio_path"] or (self.is_v2pro and self.prompt_cache["refer_spec"][0][1] is None)):
             if not os.path.exists(ref_audio_path):
                 raise ValueError(f"{ref_audio_path} not exists")
             self.set_ref_audio(ref_audio_path)


### PR DESCRIPTION
## 复现问题
使用api_v2，用非sovits v2pro模型推理后再切换至v2pro且用同一参考音频会引发下列错误
```
Traceback (most recent call last):
  File "E:\Program Files (x86)\GPT-SoVITS\GPT_SoVITS\TTS_infer_pack\TTS.py", line 1233, in run
    sv_emb.append(self.sv_model.compute_embedding3(audio_tensor))
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\Program Files (x86)\GPT-SoVITS\GPT_SoVITS\sv.py", line 21, in compute_embedding3
    if self.is_half==True:wav=wav.half()
                              ^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'half'
```
## 原因
可能出于性能考虑_get_ref_spec并不会为非v2Pro生成audio张量 。当使用v2Pro模型且第一个audio_tensor为None时重新做缓存