### PR TITLE
修复AMD显卡上的onnxruntime无法使用GPU的bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,13 @@ If you are a Windows user (tested with win>=10), you can [download the integrate
 
 ### Linux
 
+**Note 1: For Linux, DML Acceleration only support WSL2 or Docker on Windows. Choose DML, if you use Windows and your AMD GPU cannot use ROCm for WSL2(too old to use or just not supported Architecture) or you use Intel GPU or any other GPUs support DirectX 12(Including Core GPU)**
+**Note 2: The ROCm(AMD GPU) Acceleration of ONNX models(Powered by onnxruntime-rocm) only support Python 3.9 and 3.10 for ROCm 6.2; and Python3.9, 3.10 and 3.12 for ROCm 6.4. If you use other Python versions, GPT-Sovits will install and use CPU version of ONNX-Runtime instead.**
+
 ```bash
 conda create -n GPTSoVits python=3.10
 conda activate GPTSoVits
-bash install.sh --device <CU126|CU128|ROCM|CPU> --source <HF|HF-Mirror|ModelScope> [--download-uvr5]
+bash install.sh --device <CU126|CU128|ROCM62|ROCM64|DML|CPU> --source <HF|HF-Mirror|ModelScope> [--download-uvr5]
 ```
 
 ### macOS

--- a/README.md
+++ b/README.md
@@ -66,8 +66,11 @@ If you are a Windows user (tested with win>=10), you can [download the integrate
 
 ### Linux
 
-**Note 1: For Linux, DML Acceleration only support WSL2 or Docker on Windows. Choose DML, if you use Windows and your AMD GPU cannot use ROCm for WSL2(too old to use or just not supported Architecture) or you use Intel GPU or any other GPUs support DirectX 12(Including Core GPU)**
-**Note 2: The ROCm(AMD GPU) Acceleration of ONNX models(Powered by onnxruntime-rocm) only support Python 3.9 and 3.10 for ROCm 6.2; and Python3.9, 3.10 and 3.12 for ROCm 6.4. If you use other Python versions, GPT-Sovits will install and use CPU version of ONNX-Runtime instead.**
+**Note:**
+  
+1. **For Linux, DML Acceleration only support WSL2 or Docker on Windows. Choose DML, if you use Windows and your AMD GPU cannot use ROCm for WSL2(too old to use or just not supported Architecture) or you use Intel GPU or any other GPUs support DirectX 12(Including Core GPU).**
+  
+2. **The ROCm(AMD GPU) Acceleration of ONNX models(Powered by onnxruntime-rocm) only support Python 3.9 and 3.10 for ROCm 6.2; and Python3.9, 3.10 and 3.12 for ROCm 6.4. If you use other Python versions, GPT-Sovits will install and use CPU version of ONNX-Runtime instead.**
 
 ```bash
 conda create -n GPTSoVits python=3.10

--- a/docs/cn/README.md
+++ b/docs/cn/README.md
@@ -64,8 +64,11 @@
 
 ### Linux
 
-**注 1：对于 Linux，DML 加速仅支持 Windows 上的 WSL2 或 Docker。如果您使用 Windows，并且您的 AMD GPU 无法在 WSL2 中使用 ROCm（架构太旧或单纯的架构不支持），或者您使用 Intel GPU 或任何其他支持 DirectX 12 的 GPU（包括 核心显卡），请选择 DML**
-**注 2：ONNX 模型的 ROCm（AMD GPU）加速（由 onnxruntime-rocm 支持）仅支持 ROCm 6.2 的 Python 3.9 和 3.10；以及 ROCm 6.4 的 Python3.9、3.10 和 3.12。如果您使用其他 Python 版本，GPT-Sovits 将安装并使用 CPU 版本的 ONNX-Runtime。**
+**注:**
+  
+1. **对于 Linux，DML 加速仅支持 Windows 上的 WSL2 或 Docker。如果您使用 Windows，并且您的 AMD GPU 无法在 WSL2 中使用 ROCm（架构太旧或单纯的架构不支持），或者您使用 Intel GPU 或任何其他支持 DirectX 12 的 GPU（包括 核心显卡），请选择 DML。**
+  
+2. **ONNX 模型的 ROCm（AMD GPU）加速（由 onnxruntime-rocm 支持）仅支持 ROCm 6.2 的 Python 3.9 和 3.10；以及 ROCm 6.4 的 Python3.9、3.10 和 3.12。如果您使用其他 Python 版本，GPT-Sovits 将安装并使用 CPU 版本的 ONNX-Runtime。**
 
 ```bash
 conda create -n GPTSoVits python=3.10

--- a/docs/cn/README.md
+++ b/docs/cn/README.md
@@ -64,10 +64,13 @@
 
 ### Linux
 
+**注 1：对于 Linux，DML 加速仅支持 Windows 上的 WSL2 或 Docker。如果您使用 Windows，并且您的 AMD GPU 无法在 WSL2 中使用 ROCm（架构太旧或单纯的架构不支持），或者您使用 Intel GPU 或任何其他支持 DirectX 12 的 GPU（包括 核心显卡），请选择 DML**
+**注 2：ONNX 模型的 ROCm（AMD GPU）加速（由 onnxruntime-rocm 支持）仅支持 ROCm 6.2 的 Python 3.9 和 3.10；以及 ROCm 6.4 的 Python3.9、3.10 和 3.12。如果您使用其他 Python 版本，GPT-Sovits 将安装并使用 CPU 版本的 ONNX-Runtime。**
+
 ```bash
 conda create -n GPTSoVits python=3.10
 conda activate GPTSoVits
-bash install.sh --device <CU126|CU128|ROCM|CPU> --source <HF|HF-Mirror|ModelScope> [--download-uvr5]
+bash install.sh --device <CU126|CU128|ROCM62|ROCM64|DML|CPU> --source <HF|HF-Mirror|ModelScope> [--download-uvr5]
 ```
 
 ### macOS

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -60,10 +60,13 @@ Windows ユーザー: (Windows 10 以降でテスト済み)、[統合パッケ�
 
 ### Linux
 
+**注1: Linuxの場合、DMLアクセラレーションはWSL2またはWindows上のDockerでのみサポートされます。Windowsをご利用で、AMD GPUがWSL2でROCmを使用できない場合（アーキテクチャが古すぎるかサポートされていない）、またはIntel GPUまたはDirectX 12（コアグラフィックスを含む）をサポートするその他のGPUをご利用の場合は、DMLを選択してください**
+**注2: ONNXモデルのROCm(AMD GPU)アクセラレーション(onnxruntime-rocm搭載)は、ROCm 6.2ではPython 3.9および3.10のみ、ROCm 6.4ではPython 3.9、3.10、3.12のみをサポートします。その他のPythonバージョンをご利用の場合、GPT-Sovitsは代わりにCPUバージョンのONNX-Runtimeをインストールして使用します。**
+
 ```bash
 conda create -n GPTSoVits python=3.10
 conda activate GPTSoVits
-bash install.sh --device <CU126|CU128|ROCM|CPU> --source <HF|HF-Mirror|ModelScope> [--download-uvr5]
+bash install.sh --device <CU126|CU128|ROCM62|ROCM64|DML|CPU> --source <HF|HF-Mirror|ModelScope> [--download-uvr5]
 ```
 
 ### macOS

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -60,8 +60,11 @@ Windows ユーザー: (Windows 10 以降でテスト済み)、[統合パッケ�
 
 ### Linux
 
-**注1: Linuxの場合、DMLアクセラレーションはWSL2またはWindows上のDockerでのみサポートされます。Windowsをご利用で、AMD GPUがWSL2でROCmを使用できない場合（アーキテクチャが古すぎるかサポートされていない）、またはIntel GPUまたはDirectX 12（コアグラフィックスを含む）をサポートするその他のGPUをご利用の場合は、DMLを選択してください**
-**注2: ONNXモデルのROCm(AMD GPU)アクセラレーション(onnxruntime-rocm搭載)は、ROCm 6.2ではPython 3.9および3.10のみ、ROCm 6.4ではPython 3.9、3.10、3.12のみをサポートします。その他のPythonバージョンをご利用の場合、GPT-Sovitsは代わりにCPUバージョンのONNX-Runtimeをインストールして使用します。**
+**注:**
+  
+1. **Linuxの場合、DMLアクセラレーションはWSL2またはWindows上のDockerでのみサポートされます。Windowsをご利用で、AMD GPUがWSL2でROCmを使用できない場合（アーキテクチャが古すぎるかサポートされていない）、またはIntel GPUまたはDirectX 12（コアグラフィックスを含む）をサポートするその他のGPUをご利用の場合は、DMLを選択してください。**
+  
+2. **ONNXモデルのROCm(AMD GPU)アクセラレーション(onnxruntime-rocm搭載)は、ROCm 6.2ではPython 3.9および3.10のみ、ROCm 6.4ではPython 3.9、3.10、3.12のみをサポートします。その他のPythonバージョンをご利用の場合、GPT-Sovitsは代わりにCPUバージョンのONNX-Runtimeをインストールして使用します。**
 
 ```bash
 conda create -n GPTSoVits python=3.10

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -60,8 +60,11 @@ Windows 사용자라면 (win>=10에서 테스트됨), [통합 패키지를 다�
 
 ### Linux
 
-**참고 1: Linux의 경우 DML 가속은 Windows의 WSL2 또는 Docker에서만 지원됩니다. Windows를 사용 중이고 AMD GPU가 WSL2에서 ROCm을 사용할 수 없는 경우(아키텍처가 너무 오래되었거나 지원되지 않는 경우), 또는 Intel GPU나 DirectX 12(코어 그래픽 포함)를 지원하는 다른 GPU를 사용하는 경우 DML을 선택하세요.**
-**참고 2: ONNX 모델의 ROCm(AMD GPU) 가속(onnxruntime-rocm 기반)은 ROCm 6.2의 경우 Python 3.9 및 3.10만, ROCm 6.4의 경우 Python 3.9, 3.10 및 3.12만 지원합니다. 다른 Python 버전을 사용하는 경우, GPT-Sovits는 ONNX-Runtime의 CPU 버전을 대신 설치하여 사용합니다.**
+**주의:**
+  
+1. **Linux의 경우 DML 가속은 Windows의 WSL2 또는 Docker에서만 지원됩니다. Windows를 사용 중이고 AMD GPU가 WSL2에서 ROCm을 사용할 수 없는 경우(아키텍처가 너무 오래되었거나 지원되지 않는 경우), 또는 Intel GPU나 DirectX 12(코어 그래픽 포함)를 지원하는 다른 GPU를 사용하는 경우 DML을 선택하세요.**
+  
+2. **ONNX 모델의 ROCm(AMD GPU) 가속(onnxruntime-rocm 기반)은 ROCm 6.2의 경우 Python 3.9 및 3.10만, ROCm 6.4의 경우 Python 3.9, 3.10 및 3.12만 지원합니다. 다른 Python 버전을 사용하는 경우, GPT-Sovits는 ONNX-Runtime의 CPU 버전을 대신 설치하여 사용합니다.**
 
 ```bash
 conda create -n GPTSoVits python=3.10

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -60,10 +60,13 @@ Windows 사용자라면 (win>=10에서 테스트됨), [통합 패키지를 다�
 
 ### Linux
 
+**참고 1: Linux의 경우 DML 가속은 Windows의 WSL2 또는 Docker에서만 지원됩니다. Windows를 사용 중이고 AMD GPU가 WSL2에서 ROCm을 사용할 수 없는 경우(아키텍처가 너무 오래되었거나 지원되지 않는 경우), 또는 Intel GPU나 DirectX 12(코어 그래픽 포함)를 지원하는 다른 GPU를 사용하는 경우 DML을 선택하세요.**
+**참고 2: ONNX 모델의 ROCm(AMD GPU) 가속(onnxruntime-rocm 기반)은 ROCm 6.2의 경우 Python 3.9 및 3.10만, ROCm 6.4의 경우 Python 3.9, 3.10 및 3.12만 지원합니다. 다른 Python 버전을 사용하는 경우, GPT-Sovits는 ONNX-Runtime의 CPU 버전을 대신 설치하여 사용합니다.**
+
 ```bash
 conda create -n GPTSoVits python=3.10
 conda activate GPTSoVits
-bash install.sh --device <CU126|CU128|ROCM|CPU> --source <HF|HF-Mirror|ModelScope> [--download-uvr5]
+bash install.sh --device <CU126|CU128|ROCM62|ROCM64|DML|CPU> --source <HF|HF-Mirror|ModelScope> [--download-uvr5]
 ```
 
 ### macOS

--- a/docs/tr/README.md
+++ b/docs/tr/README.md
@@ -60,10 +60,13 @@ Eğer bir Windows kullanıcısıysanız (win>=10 ile test edilmiştir), [entegre
 
 ### Linux
 
+**Not 1: Linux için, DML hızlandırma yalnızca WSL2 veya Windows'ta Docker'da desteklenir. Windows kullanıyorsanız ve AMD GPU'nuz WSL2'de ROCm kullanamıyorsa (mimari çok eski veya basitçe desteklenmiyorsa) veya Intel GPU veya DirectX 12'yi (çekirdek grafikler dahil) destekleyen başka bir GPU kullanıyorsanız, lütfen DML'yi seçin**
+**Not 2: ONNX modellerinin ROCm(AMD GPU) Acceleration'ı (onnxruntime-rocm tarafından desteklenmektedir) yalnızca ROCm 6.2 için Python 3.9 ve 3.10'u; ROCm 6.4 için Python3.9, 3.10 ve 3.12'yi destekler. Diğer Python sürümlerini kullanıyorsanız, GPT-Sovits bunun yerine ONNX-Runtime'ın CPU sürümünü yükleyecek ve kullanacaktır.**
+
 ```bash
 conda create -n GPTSoVits python=3.10
 conda activate GPTSoVits
-bash install.sh --device <CU126|CU128|ROCM|CPU> --source <HF|HF-Mirror|ModelScope> [--download-uvr5]
+bash install.sh --device <CU126|CU128|ROCM62|ROCM64|DML|CPU> --source <HF|HF-Mirror|ModelScope> [--download-uvr5]
 ```
 
 ### macOS

--- a/docs/tr/README.md
+++ b/docs/tr/README.md
@@ -60,8 +60,11 @@ Eğer bir Windows kullanıcısıysanız (win>=10 ile test edilmiştir), [entegre
 
 ### Linux
 
-**Not 1: Linux için, DML hızlandırma yalnızca WSL2 veya Windows'ta Docker'da desteklenir. Windows kullanıyorsanız ve AMD GPU'nuz WSL2'de ROCm kullanamıyorsa (mimari çok eski veya basitçe desteklenmiyorsa) veya Intel GPU veya DirectX 12'yi (çekirdek grafikler dahil) destekleyen başka bir GPU kullanıyorsanız, lütfen DML'yi seçin**
-**Not 2: ONNX modellerinin ROCm(AMD GPU) Acceleration'ı (onnxruntime-rocm tarafından desteklenmektedir) yalnızca ROCm 6.2 için Python 3.9 ve 3.10'u; ROCm 6.4 için Python3.9, 3.10 ve 3.12'yi destekler. Diğer Python sürümlerini kullanıyorsanız, GPT-Sovits bunun yerine ONNX-Runtime'ın CPU sürümünü yükleyecek ve kullanacaktır.**
+**Not:**
+  
+1. **Linux için, DML hızlandırma yalnızca WSL2 veya Windows'ta Docker'da desteklenir. Windows kullanıyorsanız ve AMD GPU'nuz WSL2'de ROCm kullanamıyorsa (mimari çok eski veya basitçe desteklenmiyorsa) veya Intel GPU veya DirectX 12'yi (çekirdek grafikler dahil) destekleyen başka bir GPU kullanıyorsanız, lütfen DML'yi seçin.**
+  
+2. **ONNX modellerinin ROCm(AMD GPU) Acceleration'ı (onnxruntime-rocm tarafından desteklenmektedir) yalnızca ROCm 6.2 için Python 3.9 ve 3.10'u; ROCm 6.4 için Python3.9, 3.10 ve 3.12'yi destekler. Diğer Python sürümlerini kullanıyorsanız, GPT-Sovits bunun yerine ONNX-Runtime'ın CPU sürümünü yükleyecek ve kullanacaktır.**
 
 ```bash
 conda create -n GPTSoVits python=3.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,6 @@ numba
 pytorch-lightning>=2.4
 gradio<5
 ffmpeg-python
-onnxruntime; platform_machine == "aarch64" or platform_machine == "arm64"
-onnxruntime-gpu; platform_machine == "x86_64" or platform_machine == "AMD64"
 tqdm
 funasr==1.0.27
 cn2an

--- a/tools/uvr5/mdxnet.py
+++ b/tools/uvr5/mdxnet.py
@@ -82,6 +82,7 @@ class Predictor:
             os.path.join(args.onnx, self.model_.target_name + ".onnx"),
             providers=[
                 "CUDAExecutionProvider",
+                "ROCMExecutionProvider",
                 "DmlExecutionProvider",
                 "CPUExecutionProvider",
             ],


### PR DESCRIPTION
1. 优化安装方式，如果为ROCM则安装onnxruntime-rocm，而不是onnxruntime-gpu。如果使用wsl且为dml，则安装torch-directml和onnxruntime-directml，而不是cuda版的torch和onnxruntime-gpu
2. 优化调用ONNX runtime的ExecutionProvider的调用逻辑。先列出来所有可用的ExecutionProvider，首先如果有CUDA则调用CUDAExecutionProvider，其次如果有ROCM则调用ROCMExecutionProvider，再次如果有DML则调用DmlExecutionProvider。最后添加CPUExecutionProvider。
3. 添加ROCMExecutionProvider到列表。
4. 修改五个语言版本的README

**5. 如果使用任何支持DX12的GPU，都可以使用torch-directml和onnxruntime-directml（因此希望Windows整合包也可以添加上我做的这些修改）**