### PR TITLE
Update export_torch_script.py 修复导出过程中精度不匹配

### DIFF
--- a/GPT_SoVITS/export_torch_script.py
+++ b/GPT_SoVITS/export_torch_script.py
@@ -474,6 +474,10 @@ class T2SModel(nn.Module):
         bert = bert.unsqueeze(0)
 
         x = self.ar_text_embedding(all_phoneme_ids)
+
+        # avoid dtype inconsistency when exporting
+        bert = bert.to(dtype=self.bert_proj.weight.dtype)
+        
         x = x + self.bert_proj(bert.transpose(1, 2))
         x: torch.Tensor = self.ar_text_position(x)
 


### PR DESCRIPTION
Avoid dtype inconsistency when exporting.

This is the code I was using 

```
python GPT_SoVITS/c.py \
    --gpt_model /home/user1/workspace/bobchenyx/doubao/txdb-e15.ckpt \
    --sovits_model /home/user1/workspace/bobchenyx/doubao/txdb_e12_s204.pth \
    --ref_audio /home/user1/workspace/bobchenyx/doubao/doubao-ref-ours.wav \
    --ref_text /home/user1/workspace/bobchenyx/doubao/doubao-ref.txt \
    --output_path /home/user1/workspace/bobchenyx/doubao-export \
    --device cpu \
    --no-half
```

And I've met this kind of issue.

```
Traceback (most recent call last):
  File "/home/user1/workspace/bobchenyx/GPT-SoVITS/GPT_SoVITS/export_torch_script.py", line 1096, in <module>
    main()
  File "/home/user1/workspace/bobchenyx/GPT-SoVITS/GPT_SoVITS/export_torch_script.py", line 1083, in main
    export(
  File "/home/user1/workspace/bobchenyx/GPT-SoVITS/GPT_SoVITS/export_torch_script.py", line 716, in export
    gpt_sovits_export = torch.jit.trace(
  File "/home/user1/anaconda3/envs/GPTSoVits/lib/python3.10/site-packages/torch/jit/_trace.py", line 1002, in trace
    traced_func = _trace_impl(
  File "/home/user1/anaconda3/envs/GPTSoVits/lib/python3.10/site-packages/torch/jit/_trace.py", line 696, in _trace_impl
    return trace_module(
  File "/home/user1/anaconda3/envs/GPTSoVits/lib/python3.10/site-packages/torch/jit/_trace.py", line 1279, in trace_module
    module._c._create_method_from_trace(
  File "/home/user1/anaconda3/envs/GPTSoVits/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/user1/anaconda3/envs/GPTSoVits/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/user1/anaconda3/envs/GPTSoVits/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1741, in _slow_forward
    result = self.forward(*input, **kwargs)
  File "/home/user1/workspace/bobchenyx/GPT-SoVITS/GPT_SoVITS/export_torch_script.py", line 876, in forward
    pred_semantic = self.t2s(prompts, ref_seq, text_seq, ref_bert, text_bert, top_k)
  File "/home/user1/anaconda3/envs/GPTSoVits/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/user1/anaconda3/envs/GPTSoVits/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/user1/anaconda3/envs/GPTSoVits/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1730, in _slow_forward
    return self.forward(*input, **kwargs)
RuntimeError: The following operation failed in the TorchScript interpreter.
Traceback of TorchScript (most recent call last):
  File "/home/user1/workspace/bobchenyx/GPT-SoVITS/GPT_SoVITS/export_torch_script.py", line 477, in forward
    
        x = self.ar_text_embedding(all_phoneme_ids)
        x = x + self.bert_proj(bert.transpose(1, 2))
                ~~~~~~~~~~~~~~ <--- HERE
        x: torch.Tensor = self.ar_text_position(x)
    
  File "/home/user1/anaconda3/envs/GPTSoVits/lib/python3.10/site-packages/torch/nn/modules/linear.py", line 125, in forward
    def forward(self, input: Tensor) -> Tensor:
        return F.linear(input, self.weight, self.bias)
               ~~~~~~~~ <--- HERE
RuntimeError: expected m1 and m2 to have the same dtype, but got: c10::Half != float
```