### PR TITLE
修复gpt的loss计算问题

### DIFF
--- a/GPT_SoVITS/configs/tts_infer.yaml
+++ b/GPT_SoVITS/configs/tts_infer.yaml
@@ -3,9 +3,9 @@ custom:
   cnhuhbert_base_path: GPT_SoVITS/pretrained_models/chinese-hubert-base
   device: cuda
   is_half: true
-  t2s_weights_path: "GPT_weights_v2Pro/\u97F5\u513F-e15.ckpt"
+  t2s_weights_path: GPT_SoVITS/pretrained_models/gsv-v2final-pretrained/s1bert25hz-5kh-longer-epoch=12-step=369668.ckpt
   version: v2
-  vits_weights_path: "SoVITS_weights_v2/\u97F5\u513F_e25_s9475.pth"
+  vits_weights_path: GPT_SoVITS/pretrained_models/gsv-v2final-pretrained/s2G2333k.pth
 v1:
   bert_base_path: GPT_SoVITS/pretrained_models/chinese-roberta-wwm-ext-large
   cnhuhbert_base_path: GPT_SoVITS/pretrained_models/chinese-hubert-base

--- a/GPT_SoVITS/configs/tts_infer.yaml
+++ b/GPT_SoVITS/configs/tts_infer.yaml
@@ -3,9 +3,9 @@ custom:
   cnhuhbert_base_path: GPT_SoVITS/pretrained_models/chinese-hubert-base
   device: cuda
   is_half: true
-  t2s_weights_path: GPT_SoVITS/pretrained_models/gsv-v2final-pretrained/s1bert25hz-5kh-longer-epoch=12-step=369668.ckpt
+  t2s_weights_path: "GPT_weights_v2Pro/\u97F5\u513F-e15.ckpt"
   version: v2
-  vits_weights_path: GPT_SoVITS/pretrained_models/gsv-v2final-pretrained/s2G2333k.pth
+  vits_weights_path: "SoVITS_weights_v2/\u97F5\u513F_e25_s9475.pth"
 v1:
   bert_base_path: GPT_SoVITS/pretrained_models/chinese-roberta-wwm-ext-large
   cnhuhbert_base_path: GPT_SoVITS/pretrained_models/chinese-hubert-base


### PR DESCRIPTION
#### 问题
- 现行gpt的loss计算方式没有考虑y[0]的loss (x->y[0])，这可能对gpt的无参考音频模式产生影响。
#### 解决方式
- 更改x_mask的padding mask为left（不然的话x和y之间有gap），更改loss计算方式（考虑y[0]的情况）
#### 影响
- 直接合并该PR会影响现有预训练权重的微调。最直观的就是top3 acc下降了（毕竟预训练模型没有见过x->y[0]的情况）
- 观察到微调之后，无参考文本模式胡说的概率少了。
- 慎重考虑合并！
