### PR TITLE
refactor: inference_cli for more input param choice targeting inferece_webui

### DIFF
--- a/GPT_SoVITS/inference_cli.py
+++ b/GPT_SoVITS/inference_cli.py
@@ -12,19 +12,12 @@ def synthesize(
     GPT_model_path,
     SoVITS_model_path,
     ref_audio_path,
-    ref_text_path,
+    ref_text,
     ref_language,
-    target_text_path,
+    target_text,
     target_language,
     output_path,
 ):
-    # Read reference text
-    with open(ref_text_path, "r", encoding="utf-8") as file:
-        ref_text = file.read()
-
-    # Read target text
-    with open(target_text_path, "r", encoding="utf-8") as file:
-        target_text = file.read()
 
     # Change model weights
     change_gpt_weights(gpt_path=GPT_model_path)
@@ -45,34 +38,106 @@ def synthesize(
 
     if result_list:
         last_sampling_rate, last_audio_data = result_list[-1]
+        # Create output directory if it doesn't exist
+        os.makedirs(output_path, exist_ok=True)
         output_wav_path = os.path.join(output_path, "output.wav")
         sf.write(output_wav_path, last_audio_data, last_sampling_rate)
         print(f"Audio saved to {output_wav_path}")
 
 
-def main():
+def build_parser():
     parser = argparse.ArgumentParser(description="GPT-SoVITS Command Line Tool")
-    parser.add_argument("--gpt_model", required=True, help="Path to the GPT model file")
-    parser.add_argument("--sovits_model", required=True, help="Path to the SoVITS model file")
+
+    # input settings
     parser.add_argument("--ref_audio", required=True, help="Path to the reference audio file")
-    parser.add_argument("--ref_text", required=True, help="Path to the reference text file")
-    parser.add_argument(
-        "--ref_language", required=True, choices=["中文", "英文", "日文"], help="Language of the reference audio"
-    )
-    parser.add_argument("--target_text", required=True, help="Path to the target text file")
-    parser.add_argument(
-        "--target_language",
-        required=True,
-        choices=["中文", "英文", "日文", "中英混合", "日英混合", "多语种混合"],
-        help="Language of the target text",
-    )
+    parser.add_argument("--ref_text", required=True, help="Transcript of the reference audio")
+    parser.add_argument("--ref_language", required=True,
+                       choices=["中文", "英文", "日文", "韩文", "粤语"], help="Language of the reference audio")
+
+    # output settings
+    parser.add_argument("--target_text", required=True, help="Text to be synthesized")
+    parser.add_argument("--target_language", required=True,
+                       choices=["中文", "英文", "日文", "中英混合", "日英混合", "多语种混合"],
+                       help="Language of the target text")
     parser.add_argument("--output_path", required=True, help="Path to the output directory")
 
+    sub = parser.add_subparsers(dest="mode", required=True)
+
+    # Mode 1: provide model paths directly
+    p_paths = sub.add_parser("paths", help="Use explicit model file paths")
+    p_paths.add_argument("--gpt_path", required=True, help="Path to the GPT model file")
+    p_paths.add_argument("--sovits_path", required=True, help="Path to the SoVITS model file")
+
+    # Mode 2: select by experiment/version
+    p_sel = sub.add_parser("select", help="Select models by experiment/version")
+    p_sel.add_argument("--exp_name", required=True, help="Experiment name")
+    available_gpt_versions = ["v1", "v2", "v2Pro", "v2ProPlus", "v3", "v4"]
+    p_sel.add_argument("--gpt_version", required=True, choices=available_gpt_versions, help="Version of the GPT model")
+    available_sovits_versions = ["v1", "v2", "v2Pro", "v2ProPlus", "v3", "v4"]
+    p_sel.add_argument("--sovits_version", required=True, choices=available_sovits_versions, help="Version of the SoVITS model")
+    p_sel.add_argument("--gpt_epoch", type=int, help="Epoch of the GPT model")
+    p_sel.add_argument("--sovits_epoch", type=int, help="Epoch of the SoVITS model")
+
+    return parser
+
+
+def get_model_path(args)->argparse.Namespace:
+    """
+    Get the model path from exp_name, version and epoch
+
+    Args:
+        args: argparse.Namespace
+
+    Returns:
+        args: argparse.Namespace
+    """
+    exist_gpt_path = []
+    exist_sovits_path = []
+
+    def _get_model_dir(model_type, version):
+        if version == "v1":
+            return f"{model_type}_weights"
+        else:
+            return f"{model_type}_weights_{version}"
+
+    # get all the model paths with the same exp_name
+    for files in os.listdir(_get_model_dir("GPT", args.gpt_version)):
+        if args.exp_name in files and files.endswith(".ckpt"):
+            exist_gpt_path.append(os.path.join(_get_model_dir("GPT", args.gpt_version), files))
+    for files in os.listdir(_get_model_dir("SoVITS", args.sovits_version)):
+        if args.exp_name in files and files.endswith(".pth"):
+            exist_sovits_path.append(os.path.join(_get_model_dir("SoVITS", args.sovits_version), files))
+
+    # get the largest epoch if not specified
+    if args.gpt_epoch:
+        args.gpt_path = [i for i in exist_gpt_path if f"e{args.gpt_epoch}" in i]
+    else:
+        args.gpt_path = sorted(exist_gpt_path)[-1]
+    if args.sovits_epoch:
+        args.sovits_path = [i for i in exist_sovits_path if f"e{args.sovits_epoch}" in i]
+    else:
+        args.sovits_path = sorted(exist_sovits_path)[-1]
+
+    if not args.gpt_path or not args.sovits_path:
+        raise ValueError("No model found")
+    
+    return args
+
+
+def main():
+    parser = build_parser()
     args = parser.parse_args()
 
+    print(args)
+    if args.mode == "select":
+        args = get_model_path(args)
+    
+    args.target_text = args.target_text.replace("'", "").replace('"', "")
+
+
     synthesize(
-        args.gpt_model,
-        args.sovits_model,
+        args.gpt_path,
+        args.sovits_path,
         args.ref_audio,
         args.ref_text,
         args.ref_language,

--- a/GPT_SoVITS/inference_cli.py
+++ b/GPT_SoVITS/inference_cli.py
@@ -7,6 +7,9 @@ from GPT_SoVITS.inference_webui import change_gpt_weights, change_sovits_weights
 
 i18n = I18nAuto()
 
+LANGUAGE_CHOICES = ["中文", "英文", "日文", "韩文", "粤语"]
+MIXED_LANGUAGE_CHOICES = ["中英混合", "日英混合", "粤英混合", "韩英混合", "多语种混合"]
+
 
 def synthesize(
     GPT_model_path,
@@ -52,12 +55,12 @@ def build_parser():
     parser.add_argument("--ref_audio", required=True, help="Path to the reference audio file")
     parser.add_argument("--ref_text", required=True, help="Transcript of the reference audio")
     parser.add_argument("--ref_language", required=True,
-                       choices=["中文", "英文", "日文", "韩文", "粤语"], help="Language of the reference audio")
+                       choices=LANGUAGE_CHOICES, help="Language of the reference audio")
 
     # output settings
     parser.add_argument("--target_text", required=True, help="Text to be synthesized")
     parser.add_argument("--target_language", required=True,
-                       choices=["中文", "英文", "日文", "中英混合", "日英混合", "多语种混合"],
+                       choices=LANGUAGE_CHOICES+MIXED_LANGUAGE_CHOICES,
                        help="Language of the target text")
     parser.add_argument("--output_path", required=True, help="Path to the output directory")
 

--- a/GPT_SoVITS/inference_webui.py
+++ b/GPT_SoVITS/inference_webui.py
@@ -180,6 +180,8 @@ def get_bert_feature(text, word2ph):
     for i in range(len(word2ph)):
         repeat_feature = res[i].repeat(word2ph[i], 1)
         phone_level_feature.append(repeat_feature)
+    if len(phone_level_feature) == 0:
+        return torch.empty((res.shape[1], 0), dtype=res.dtype, device=res.device)
     phone_level_feature = torch.cat(phone_level_feature, dim=0)
     return phone_level_feature.T
 


### PR DESCRIPTION
# Changes
* adding missing params: There are a bunch of params missing in inference_cli.py comparing to webui which doesn't make any sense. I have added those back to inference_cli.py which should correctly point all the params to get_tts_wav. 
* better cli support: 
 1. instead of inputing the path of the text, the cli was changed to inputing text directly
 2. instead of inputing only accepting the path of the gpt and sovits model, the cli now accept selector like syntax. user can select the exp_name, epoch, version of both gpt and sovits model separately. Path model is also kept.
 
 # Usage example
 ## path mode
```python
python GPT_SoVITS/inference_cil.py\
                --ref_audio "audio_path" --ref_text "text" --ref_language "中文" \
                --target_text "text" --target_language "中文" \
                --slicer "按标点符号切" \
                --output_path "OUTPUT" \
                path --gpt_path "path" --sovits_path "path"
```


 ## selector mode
```python
 python GPT_SoVITS/inference_cil.py \
                --ref_audio "audio_path" --ref_text "text" --ref_language "中文" \
                --target_text "text" --target_language "中文" \
                --slicer "按标点符号切" \
                --output_path "OUTPUT" \
                select \
                --exp_name "xxx" \
                --gpt_version "v2Pro" --sovits_version "v4" \
                --gpt_epoch "test" #if epoch is not found, the largest will be used
```
 