### PR TITLE
Handling cases where the length of semantic_phoneme may be 0

### DIFF
--- a/GPT_SoVITS/AR/data/dataset.py
+++ b/GPT_SoVITS/AR/data/dataset.py
@@ -176,6 +176,9 @@ class Text2SemanticDataset(Dataset):
 
         min_num = 100  # 20直接不补#30补了也不存ckpt
         leng = len(self.semantic_phoneme)
+        print("leng: ", leng)
+        if leng == 0:
+            leng = min_num
         if leng < min_num:
             tmp1 = self.semantic_phoneme
             tmp2 = self.item_names


### PR DESCRIPTION
可以在终端看到更清晰的错误，而不是代码的 ERROR Stack信息。
You can see clearer errors in the terminal instead of the ERROR Stack information in the code.