### PR TITLE
限制ffmpeg版本，最新版不兼容

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ librosa==0.10.2
 numba
 pytorch-lightning>=2.4
 gradio<5
-ffmpeg-python
+ffmpeg-python==0.1.18
 onnxruntime; platform_machine == "aarch64" or platform_machine == "arm64"
 onnxruntime-gpu; platform_machine == "x86_64" or platform_machine == "AMD64"
 tqdm


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/srv/AI/TTS/GPT-SoVITS/GPT_SoVITS/prepare_datasets/2-get-hubert-wav32k.py", line 123, in <module>
    name2go(wav_name, wav_path)
  File "/srv/AI/TTS/GPT-SoVITS/GPT_SoVITS/prepare_datasets/2-get-hubert-wav32k.py", line 82, in name2go
    tmp_audio = load_audio(wav_path, 32000)
  File "/srv/AI/TTS/GPT-SoVITS/tools/my_utils.py", line 31, in load_audio
    ffmpeg.input(file, threads=0)
AttributeError: module 'ffmpeg' has no attribute 'input'
```

经过排查发现 ffmpeg-python 最新版 0.2.0 重构了工具包的架构，改了调用方式
版本过低则会报错`TypeError: get_args() got an unexpected keyword argument 'capture_stdout'`
最后直接强制使用0.1.18版本后排除问题

```
(SoVITS-NV12.8) xl8z@xl8z-local-main:/srv/AI/TTS/GPT-SoVITS$ pip install ffmpeg-python
Looking in indexes: https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
Requirement already satisfied: ffmpeg-python in ./venv/lib/python3.10/site-packages (0.2.0)
Requirement already satisfied: future in ./venv/lib/python3.10/site-packages (from ffmpeg-python) (1.0.0)
(SoVITS-NV12.8) xl8z@xl8z-local-main:/srv/AI/TTS/GPT-SoVITS$ python
Python 3.10.12 (main, Aug 15 2025, 14:32:43) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import ffmpeg
>>>
>>>
>>> ffmpeg
<module 'ffmpeg' (<_frozen_importlib_external._NamespaceLoader object at 0x7f169cba3490>)>
>>> ffmpeg.__
ffmpeg.__annotations__     ffmpeg.__gt__(             ffmpeg.__path__
ffmpeg.__class__(          ffmpeg.__hash__()          ffmpeg.__reduce__()
ffmpeg.__delattr__(        ffmpeg.__init__(           ffmpeg.__reduce_ex__(
ffmpeg.__dict__            ffmpeg.__init_subclass__(  ffmpeg.__repr__()
ffmpeg.__dir__(            ffmpeg.__le__(             ffmpeg.__setattr__(
ffmpeg.__doc__             ffmpeg.__loader__          ffmpeg.__sizeof__()
ffmpeg.__eq__(             ffmpeg.__lt__(             ffmpeg.__spec__
ffmpeg.__file__            ffmpeg.__name__            ffmpeg.__str__()
ffmpeg.__format__(         ffmpeg.__ne__(             ffmpeg.__subclasshook__(
ffmpeg.__ge__(             ffmpeg.__new__(
ffmpeg.__getattribute__(   ffmpeg.__package__

```