### PR TITLE
修复由于 default_batch_size(_s1) 变量为浮点型造成训练失败的问题

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -117,8 +117,8 @@ def set_default():
     gpu_info = "\n".join(gpu_infos)
     if is_gpu_ok:
         minmem = min(mem)
-        default_batch_size = minmem // 2 if version not in v3v4set else minmem // 8
-        default_batch_size_s1 = minmem // 2
+        default_batch_size = int(minmem // 2 if version not in v3v4set else minmem // 8)
+        default_batch_size_s1 = int(minmem // 2)
     else:
         default_batch_size = default_batch_size_s1 = int(psutil.virtual_memory().total / 1024 / 1024 / 1024 / 4)
     if version not in v3v4set:


### PR DESCRIPTION
修复`default_batch_size parameter` (以及 `default_batch_size parameter_s1`) 为浮点型造成的训练失败报错
Fix training error caused by float type of `default_batch_size parameter` (and `default_batch_size parameter_s1`), otherwise you will encounter error like this:
```cmd
batch_size should be a positive integer value, but got batch_size=4.0
```