### PR TITLE
Change default top_k value to 15 for consistency

### DIFF
--- a/GPT_SoVITS/inference_webui.py
+++ b/GPT_SoVITS/inference_webui.py
@@ -755,7 +755,7 @@ def get_tts_wav(
     text,
     text_language,
     how_to_cut=i18n("不切"),
-    top_k=20,
+    top_k=15,
     top_p=0.6,
     temperature=0.6,
     ref_free=False,


### PR DESCRIPTION
修复 [对齐gpt topk默认采样参数](https://github.com/RVC-Boss/GPT-SoVITS/commit/abe984395cb6d8ed2055f5496d0bb26007f30365) 时遗漏的 `inference_webui.py` 中 `top_k` 的默认值