### PR TITLE
fix: correct torch.randint exclusive upper bound

### DIFF
--- a/GPT_SoVITS/AR/models/utils.py
+++ b/GPT_SoVITS/AR/models/utils.py
@@ -262,7 +262,7 @@ def make_reject_y(y_o, y_lens):
     reject_y = []
     reject_y_lens = []
     for b in range(bs):
-        process_item_idx = torch.randint(0, 1, size=(1,))[0]
+        process_item_idx = torch.randint(0, 2, size=(1,))[0]
         if process_item_idx == 0:
             new_y = repeat_P(y_o[b])
             reject_y.append(new_y)


### PR DESCRIPTION
## Bug
`torch.randint(0, 1, ...)` always returns 0 because PyTorch's `randint` upper bound is exclusive (unlike Python's `random.randint`). This makes the `lost_P` branch in `make_reject_y` unreachable.

## Fix
Changed upper bound from 1 to 2 so both 0 and 1 can be generated, making both code paths (`repeat_P` and `lost_P`) reachable.