### PR TITLE
Security - Replace eval() with safe boolean parsing

### DIFF
--- a/GPT_SoVITS/inference_webui.py
+++ b/GPT_SoVITS/inference_webui.py
@@ -83,11 +83,10 @@ cnhubert_base_path = os.environ.get("cnhubert_base_path", "GPT_SoVITS/pretrained
 bert_path = os.environ.get("bert_path", "GPT_SoVITS/pretrained_models/chinese-roberta-wwm-ext-large")
 infer_ttswebui = os.environ.get("infer_ttswebui", 9872)
 infer_ttswebui = int(infer_ttswebui)
-is_share = os.environ.get("is_share", "False")
-is_share = eval(is_share)
+is_share = os.environ.get("is_share", "False").lower() in ("true", "1", "yes")
 if "_CUDA_VISIBLE_DEVICES" in os.environ:
     os.environ["CUDA_VISIBLE_DEVICES"] = os.environ["_CUDA_VISIBLE_DEVICES"]
-is_half = eval(os.environ.get("is_half", "True")) and torch.cuda.is_available()
+is_half = os.environ.get("is_half", "True").lower() in ("true", "1", "yes") and torch.cuda.is_available()
 # is_half=False
 punctuation = set(["!", "?", "…", ",", ".", "-", " "])
 import gradio as gr

--- a/GPT_SoVITS/inference_webui_fast.py
+++ b/GPT_SoVITS/inference_webui_fast.py
@@ -44,12 +44,11 @@ logging.getLogger("torchaudio._extension").setLevel(logging.ERROR)
 
 infer_ttswebui = os.environ.get("infer_ttswebui", 9872)
 infer_ttswebui = int(infer_ttswebui)
-is_share = os.environ.get("is_share", "False")
-is_share = eval(is_share)
+is_share = os.environ.get("is_share", "False").lower() in ("true", "1", "yes")
 if "_CUDA_VISIBLE_DEVICES" in os.environ:
     os.environ["CUDA_VISIBLE_DEVICES"] = os.environ["_CUDA_VISIBLE_DEVICES"]
 
-is_half = eval(os.environ.get("is_half", "True")) and torch.cuda.is_available()
+is_half = os.environ.get("is_half", "True").lower() in ("true", "1", "yes") and torch.cuda.is_available()
 gpt_path = os.environ.get("gpt_path", None)
 sovits_path = os.environ.get("sovits_path", None)
 cnhubert_base_path = os.environ.get("cnhubert_base_path", None)

--- a/GPT_SoVITS/prepare_datasets/1-get-text.py
+++ b/GPT_SoVITS/prepare_datasets/1-get-text.py
@@ -13,7 +13,7 @@ opt_dir = os.environ.get("opt_dir")
 bert_pretrained_dir = os.environ.get("bert_pretrained_dir")
 import torch
 
-is_half = eval(os.environ.get("is_half", "True")) and torch.cuda.is_available()
+is_half = os.environ.get("is_half", "True").lower() in ("true", "1", "yes") and torch.cuda.is_available()
 version = os.environ.get("version", None)
 import traceback
 import os.path

--- a/GPT_SoVITS/prepare_datasets/2-get-hubert-wav32k.py
+++ b/GPT_SoVITS/prepare_datasets/2-get-hubert-wav32k.py
@@ -16,7 +16,7 @@ opt_dir = os.environ.get("opt_dir")
 cnhubert.cnhubert_base_path = os.environ.get("cnhubert_base_dir")
 import torch
 
-is_half = eval(os.environ.get("is_half", "True")) and torch.cuda.is_available()
+is_half = os.environ.get("is_half", "True").lower() in ("true", "1", "yes") and torch.cuda.is_available()
 
 import traceback
 import numpy as np

--- a/GPT_SoVITS/prepare_datasets/2-get-sv.py
+++ b/GPT_SoVITS/prepare_datasets/2-get-sv.py
@@ -15,7 +15,7 @@ opt_dir = os.environ.get("opt_dir")
 sv_path = os.environ.get("sv_path")
 import torch
 
-is_half = eval(os.environ.get("is_half", "True")) and torch.cuda.is_available()
+is_half = os.environ.get("is_half", "True").lower() in ("true", "1", "yes") and torch.cuda.is_available()
 
 import traceback
 import torchaudio

--- a/GPT_SoVITS/prepare_datasets/3-get-semantic.py
+++ b/GPT_SoVITS/prepare_datasets/3-get-semantic.py
@@ -28,7 +28,7 @@ else:
     version = "v3"
 import torch
 
-is_half = eval(os.environ.get("is_half", "True")) and torch.cuda.is_available()
+is_half = os.environ.get("is_half", "True").lower() in ("true", "1", "yes") and torch.cuda.is_available()
 import traceback
 import sys
 

--- a/tools/subfix_webui.py
+++ b/tools/subfix_webui.py
@@ -420,6 +420,6 @@ if __name__ == "__main__":
         server_name="0.0.0.0",
         inbrowser=True,
         # quiet=True,
-        share=eval(args.is_share),
+        share=args.is_share.lower() in ("true", "1", "yes"),
         server_port=int(args.webui_port_subfix),
     )

--- a/tools/uvr5/webui.py
+++ b/tools/uvr5/webui.py
@@ -25,9 +25,9 @@ for name in os.listdir(weight_uvr5_root):
         uvr5_names.append(name.replace(".pth", "").replace(".ckpt", ""))
 
 device = sys.argv[1]
-is_half = eval(sys.argv[2])
+is_half = sys.argv[2].lower() in ("true", "1", "yes")
 webui_port_uvr5 = int(sys.argv[3])
-is_share = eval(sys.argv[4])
+is_share = sys.argv[4].lower() in ("true", "1", "yes")
 
 
 def html_left(text, label="p"):


### PR DESCRIPTION
## Summary

Replace all uses of `eval()` on environment variables and command-line arguments with safe string comparison to prevent arbitrary code execution.

## Problem

`eval()` on user-controllable strings (env vars, `sys.argv`) allows arbitrary Python code execution. For example:

```bash
# This would execute arbitrary code:
is_half="__import__('os').system('rm -rf /')" python inference_webui.py
```

There are **10 such call sites** across 8 files.

## Fix

Replace:
```python
is_half = eval(os.environ.get("is_half", "True"))
```

With:
```python
is_half = os.environ.get("is_half", "True").lower() in ("true", "1", "yes")
```

This produces identical behavior for all valid boolean inputs (`True`, `False`, `true`, `false`, `1`, `0`) while preventing code injection.

> **Note**: `config.py` already uses this safe pattern — this PR makes the rest of the codebase consistent.

## Changed files

| File | Variables fixed |
|---|---|
| `GPT_SoVITS/inference_webui.py` | `is_share`, `is_half` |
| `GPT_SoVITS/inference_webui_fast.py` | `is_share`, `is_half` |
| `GPT_SoVITS/prepare_datasets/1-get-text.py` | `is_half` |
| `GPT_SoVITS/prepare_datasets/2-get-hubert-wav32k.py` | `is_half` |
| `GPT_SoVITS/prepare_datasets/2-get-sv.py` | `is_half` |
| `GPT_SoVITS/prepare_datasets/3-get-semantic.py` | `is_half` |
| `tools/uvr5/webui.py` | `is_half`, `is_share` |
| `tools/subfix_webui.py` | `is_share` |

## Testing

- All 8 files pass `python -m py_compile` with no new errors
- No behavioral change for valid boolean inputs (`True`/`False`)