### PR TITLE
fix: 修复 TTS 音频后处理中的关键缺陷（int16 溢出 / padding_len=0 / 异常类型）

### DIFF
--- a/GPT_SoVITS/TTS_infer_pack/TTS.py
+++ b/GPT_SoVITS/TTS_infer_pack/TTS.py
@@ -499,7 +499,7 @@ class TTS:
 
         if if_lora_v3 == True and os.path.exists(path_sovits) == False:
             info = path_sovits + i18n("SoVITS %s 底模缺失，无法加载相应 LoRA 权重" % model_version)
-            raise FileExistsError(info)
+            raise FileNotFoundError(info)
 
         # dict_s2 = torch.load(weights_path, map_location=self.configs.device,weights_only=False)
         dict_s2 = load_sovits_new(weights_path)
@@ -1578,16 +1578,15 @@ class TTS:
                 max_audio = np.abs(audio).max()
                 if max_audio > 1:
                     audio /= max_audio
-            audio = (audio * 32768).astype(np.int16)
+                audio = (audio * 32768).astype(np.int16)
+            else:
+                audio = audio.cpu().numpy()
+                audio = (audio * 32768).astype(np.int16)
             t2 = time.perf_counter()
             print(f"超采样用时：{t2 - t1:.3f}s")
         else:
-            # audio = audio.float() * 32768
-            # audio = audio.to(dtype=torch.int16).clamp(-32768, 32767).cpu().numpy()
-
             audio = audio.cpu().numpy()
-
-        audio = (audio * 32768).astype(np.int16)
+            audio = (audio * 32768).astype(np.int16)
 
 
         # try:
@@ -1768,7 +1767,10 @@ class TTS:
             pos += chunk_len * upsample_rate
 
         audio = self.sola_algorithm(audio_fragments, overlapped_len * upsample_rate)
-        audio = audio[overlapped_len * upsample_rate : -padding_len * upsample_rate]
+        if padding_len > 0:
+            audio = audio[overlapped_len * upsample_rate : -padding_len * upsample_rate]
+        else:
+            audio = audio[overlapped_len * upsample_rate :]
 
         audio_fragments = []
         for feat_len in feat_lens:


### PR DESCRIPTION
## 问题描述

在 `GPT_SoVITS/TTS_infer_pack/TTS.py` 的 `audio_postprocess` 方法中发现三个 bug：

### 1. [CRITICAL] 音频超采样时 int16 双重转换导致整数溢出

第 1590 行 `audio = (audio * 32768).astype(np.int16)` 位于 `if super_sampling / else` 块之外，无条件执行。

当 `super_sampling=True` 时：
- 第 1581 行已将音频转为 int16（值域 -32768~32767）
- 第 1590 行再次乘以 32768 → 整数溢出 → **输出音频完全失真**

此外，当 `super_sampling=True` 但超分模型文件不存在时，`audio` 仍为 `torch.Tensor`，
调用 `.astype()` 会抛出 `AttributeError`。

### 2. [HIGH] padding_len=0 时 batched vocoder 推理音频丢失

`batched_decode` 方法中，当最后一个 chunk 刚好填满（`padding_len == 0`）时：
`-0 * upsample_rate == 0`，切片变为 `audio[x:0]`，返回空张量，导致整段音频丢失。

### 3. [LOW] 文件不存在时错误地抛出 FileExistsError

第 502 行在 LoRA 底模文件不存在时抛出 `FileExistsError`，应为 `FileNotFoundError`。

## 修改内容

- 将无条件的 int16 转换移入各分支内部，分别处理超分模型存在/不存在的情况
- 对 `padding_len == 0` 增加条件判断，避免空切片
- 修正异常类型

## 测试方案

- [ ] 开启 `super_sampling=True` 进行 TTS 推理，验证音频输出正常
- [ ] 使用长度恰好对齐的文本测试 `padding_len=0` 边界条件
- [ ] 在缺少 LoRA 底模时触发加载，验证异常类型正确