### PR TITLE
fix: 修复 API 输入验证和参数处理中的多个缺陷

### DIFF
--- a/GPT_SoVITS/inference_webui.py
+++ b/GPT_SoVITS/inference_webui.py
@@ -84,10 +84,10 @@ bert_path = os.environ.get("bert_path", "GPT_SoVITS/pretrained_models/chinese-ro
 infer_ttswebui = os.environ.get("infer_ttswebui", 9872)
 infer_ttswebui = int(infer_ttswebui)
 is_share = os.environ.get("is_share", "False")
-is_share = eval(is_share)
+is_share = is_share.lower() in ("true", "1", "yes")
 if "_CUDA_VISIBLE_DEVICES" in os.environ:
     os.environ["CUDA_VISIBLE_DEVICES"] = os.environ["_CUDA_VISIBLE_DEVICES"]
-is_half = eval(os.environ.get("is_half", "True")) and torch.cuda.is_available()
+is_half = os.environ.get("is_half", "True").lower() in ("true", "1", "yes") and torch.cuda.is_available()
 # is_half=False
 punctuation = set(["!", "?", "…", ",", ".", "-", " "])
 import gradio as gr

--- a/api.py
+++ b/api.py
@@ -176,9 +176,9 @@ import subprocess
 
 class DefaultRefer:
     def __init__(self, path, text, language):
-        self.path = args.default_refer_path
-        self.text = args.default_refer_text
-        self.language = args.default_refer_language
+        self.path = path
+        self.text = text
+        self.language = language
 
     def is_ready(self) -> bool:
         return is_full(self.path, self.text, self.language)
@@ -1082,11 +1082,11 @@ def handle_change(path, text, language):
             {"code": 400, "message": '缺少任意一项以下参数: "path", "text", "language"'}, status_code=400
         )
 
-    if path != "" or path is not None:
+    if path != "" and path is not None:
         default_refer.path = path
-    if text != "" or text is not None:
+    if text != "" and text is not None:
         default_refer.text = text
-    if language != "" or language is not None:
+    if language != "" and language is not None:
         default_refer.language = language
 
     logger.info(f"当前默认参考音频路径: {default_refer.path}")

--- a/api_v2.py
+++ b/api_v2.py
@@ -481,11 +481,11 @@ async def tts_get_endpoint(
 ):
     req = {
         "text": text,
-        "text_lang": text_lang.lower(),
+        "text_lang": text_lang.lower() if text_lang else "",
         "ref_audio_path": ref_audio_path,
         "aux_ref_audio_paths": aux_ref_audio_paths,
         "prompt_text": prompt_text,
-        "prompt_lang": prompt_lang.lower(),
+        "prompt_lang": prompt_lang.lower() if prompt_lang else "",
         "top_k": top_k,
         "top_p": top_p,
         "temperature": temperature,


### PR DESCRIPTION
## 问题描述

### 1. [HIGH] api.py handle_change 中 `or` 应为 `and`（条件恒真）

`/change_refer` 端点中：
```python
if path != "" or path is not None:  # 恒为 True
    default_refer.path = path
```
当 path="" 时，path is not None 为 True；当 path=None 时，path != "" 为 True。 导致未传递的参数以 None/空值覆盖已有配置。

### 2. [MEDIUM] api.py DefaultRefer.init 忽略构造函数参数
构造函数声明了 path, text, language 参数，但函数体直接引用全局 args 变量， 参数完全被忽略。

### 3. [HIGH] api_v2.py GET /tts 端点缺少 None 检查
text_lang 和 prompt_lang 默认值为 None，未提供时直接调用 None.lower() 导致 AttributeError。

### 4. [HIGH] inference_webui.py eval() 解析环境变量
eval(os.environ.get("is_share", "False")) 会执行任意 Python 代码。 项目自身的 config.py 已使用安全的字符串比较，此处改为一致的安全方式。

## 修改内容
- or → and，使条件在参数为空或 None 时不覆盖
- 构造函数直接使用传入参数
- 添加 None 保护（text_lang.lower() if text_lang else ""）
- eval() → str.lower() in ("true", "1", "yes")
## 测试方案

1. 通过 /change_refer 只更新部分参数，验证未传参数不被覆盖

2. GET /tts 不传 text_lang 参数，验证不再崩溃

3. 设置环境变量 is_share=True / is_half=False ，验证正确解析