### PR TITLE
fix: 修复多个模块中的独立 bug（distrib / spec_utils / text_seg / funasr）

### DIFF
--- a/GPT_SoVITS/TTS_infer_pack/text_segmentation_method.py
+++ b/GPT_SoVITS/TTS_infer_pack/text_segmentation_method.py
@@ -92,7 +92,7 @@ def cut0(inp):
     if not set(inp).issubset(punctuation):
         return inp
     else:
-        return "/n"
+        return "\n"
 
 
 # 凑四句一切

--- a/GPT_SoVITS/module/distrib.py
+++ b/GPT_SoVITS/module/distrib.py
@@ -87,7 +87,7 @@ def sync_buffer(buffers, average=True):
     for buffer, handle in handles:
         handle.wait()
         if average:
-            buffer.data /= world_size
+            buffer.data /= world_size()
 
 
 def sync_grad(params):

--- a/tools/asr/funasr_asr.py
+++ b/tools/asr/funasr_asr.py
@@ -39,6 +39,7 @@ def create_model(language="zh"):
             local_dir="tools/asr/models/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch",
         )
         model_revision = "v2.0.4"
+        vad_model_revision = punc_model_revision = "v2.0.4"
     elif language == "yue":
         path_asr = "tools/asr/models/speech_UniASR_asr_2pass-cantonese-CHS-16k-common-vocab1468-tensorflow1-online"
         snapshot_download(
@@ -50,8 +51,6 @@ def create_model(language="zh"):
         model_revision = "master"
     else:
         raise ValueError(f"{language} is not supported")
-
-    vad_model_revision = punc_model_revision = "v2.0.4"
 
     if language in funasr_models:
         return funasr_models[language]

--- a/tools/uvr5/lib/lib_v5/spec_utils.py
+++ b/tools/uvr5/lib/lib_v5/spec_utils.py
@@ -485,6 +485,8 @@ def istft(spec, hl):
     wave_right = librosa.istft(spec_right, hop_length=hl)
     wave = np.asfortranarray([wave_left, wave_right])
 
+    return wave
+
 
 if __name__ == "__main__":
     import argparse


### PR DESCRIPTION
## 问题描述

修复分散在 4 个不同模块中的独立 bug：

### 1. [HIGH] distrib.py sync_buffer 除以函数对象

`buffer.data /= world_size` 中 `world_size` 是函数（定义在第 21 行），
缺少 `()` 调用，导致 `TypeError`。同文件第 108 行的 `sync_grad` 已正确使用
`world_size()`，此处是遗漏。

### 2. [HIGH] spec_utils.py istft() 缺少 return 语句

函数计算了 `wave = np.asfortranarray([wave_left, wave_right])` 但未返回，
所有调用者得到 `None`。

### 3. [MEDIUM] text_segmentation_method.py cut0 返回 "/n" 而非 "\n"

`cut0`（"不切"模式）在输入为纯标点时返回字面字符串 `"/n"` 而非换行符 `"\n"`。
后续 `text.split("\n")` 无法正确切分，`/n` 会作为文本内容传入 TTS 管线。

### 4. [HIGH] funasr_asr.py vad_model_revision 被无条件覆盖

第 54 行 `vad_model_revision = punc_model_revision = "v2.0.4"` 位于 if/elif/else
块之外，将粤语分支（不使用 VAD/标点模型）中设置的空字符串覆盖为 "v2.0.4"。

## 修改内容

- `world_size` → `world_size()`
- 添加 `return wave`
- `"/n"` → `"\n"`
- 将版本赋值移入 `if language == "zh"` 分支内

## 测试方案

- [ ] 多 GPU 分布式训练验证 sync_buffer 不再报错
- [ ] UVR5 音频处理验证 istft 返回正确数据
- [ ] 使用 "cut0"（不切）模式进行 TTS 推理
- [ ] 使用粤语（yue）进行 FunASR 语音识别