### PR TITLE
fix: torchaudio CUDA version mismatch and libnppicc missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,8 @@ COPY install.sh /workspace/GPT-SoVITS/
 
 RUN bash Docker/install_wrapper.sh
 
+RUN apt-get update && apt-get install -y libnppicc-12 && rm -rf /var/lib/apt/lists/*
+
 EXPOSE 9871 9872 9873 9874 9880
 
 ENV PYTHONPATH="/workspace/GPT-SoVITS"

--- a/install.sh
+++ b/install.sh
@@ -326,17 +326,17 @@ fi
 if [ "$USE_CUDA" = true ] && [ "$WORKFLOW" = false ]; then
     if [ "$CUDA" = 128 ]; then
         echo -e "${INFO}Installing PyTorch For CUDA 12.8..."
-        run_pip_quiet torch torchcodec --index-url "https://download.pytorch.org/whl/cu128"
+        run_pip_quiet torch torchaudio torchcodec --index-url "https://download.pytorch.org/whl/cu128"
     elif [ "$CUDA" = 126 ]; then
         echo -e "${INFO}Installing PyTorch For CUDA 12.6..."
-        run_pip_quiet torch torchcodec --index-url "https://download.pytorch.org/whl/cu126"
+        run_pip_quiet torch torchaudio torchcodec --index-url "https://download.pytorch.org/whl/cu126"
     fi
 elif [ "$USE_ROCM" = true ] && [ "$WORKFLOW" = false ]; then
     echo -e "${INFO}Installing PyTorch For ROCm 6.2..."
-    run_pip_quiet torch torchcodec --index-url "https://download.pytorch.org/whl/rocm6.2"
+    run_pip_quiet torch torchaudio torchcodec --index-url "https://download.pytorch.org/whl/rocm6.2"
 elif [ "$USE_CPU" = true ] && [ "$WORKFLOW" = false ]; then
     echo -e "${INFO}Installing PyTorch For CPU..."
-    run_pip_quiet torch torchcodec --index-url "https://download.pytorch.org/whl/cpu"
+    run_pip_quiet torch torchaudio torchcodec --index-url "https://download.pytorch.org/whl/cpu"
 elif [ "$WORKFLOW" = false ]; then
     echo -e "${ERROR}Unknown Err"
     exit 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ cn2an
 pypinyin
 pyopenjtalk>=0.4.1
 g2p_en
-torchaudio
 modelscope
 sentencepiece
 transformers>=4.43,<=4.50


### PR DESCRIPTION
## Summary
Fixes two issues with torchaudio/torchcodec in Docker container:

1. **torchaudio CUDA version mismatch**: PyTorch is installed from CUDA 12.6 index but torchaudio was being pulled from PyPI with CUDA 12.8, causing `RuntimeError: Detected that PyTorch and TorchAudio were compiled with different CUDA versions`

2. **libnppicc.so.12 missing**: torchcodec backend requires NVIDIA NPP library which was missing from the container

## Changes
- **install.sh**: Add `torchaudio` to pip install commands alongside `torch` and `torchcodec` from the same PyTorch index URL
- **requirements.txt**: Remove `torchaudio` to avoid installing wrong version from PyPI
- **Dockerfile**: Add `libnppicc-12` package installation for torchcodec dependency

## Test
Build the Docker image and run funasr_asr.py or subfix_webui.py without torchaudio/cuda version errors.