### PR TITLE
[codex] Improve Windows single-GPU v3 LoRA training / 改进 Windows 单卡 v3 LoRA 训练流程

### DIFF
--- a/GPT_SoVITS/s2_train_v3_lora.py
+++ b/GPT_SoVITS/s2_train_v3_lora.py
@@ -55,6 +55,10 @@ def main():
         n_gpus = torch.cuda.device_count()
     else:
         n_gpus = 1
+    if n_gpus <= 1:
+        run(0, n_gpus, hps)
+        return
+
     os.environ["MASTER_ADDR"] = "localhost"
     os.environ["MASTER_PORT"] = str(randint(20000, 55555))
 
@@ -77,12 +81,14 @@ def run(rank, n_gpus, hps):
         writer = SummaryWriter(log_dir=hps.s2_ckpt_dir)
         writer_eval = SummaryWriter(log_dir=os.path.join(hps.s2_ckpt_dir, "eval"))
 
-    dist.init_process_group(
-        backend="gloo" if os.name == "nt" or not torch.cuda.is_available() else "nccl",
-        init_method="env://?use_libuv=False",
-        world_size=n_gpus,
-        rank=rank,
-    )
+    use_ddp = n_gpus > 1
+    if use_ddp:
+        dist.init_process_group(
+            backend="gloo" if os.name == "nt" or not torch.cuda.is_available() else "nccl",
+            init_method="env://?use_libuv=False",
+            world_size=n_gpus,
+            rank=rank,
+        )
     torch.manual_seed(hps.train.seed)
     if torch.cuda.is_available():
         torch.cuda.set_device(rank)
@@ -118,15 +124,20 @@ def run(rank, n_gpus, hps):
         shuffle=True,
     )
     collate_fn = TextAudioSpeakerCollate()
-    train_loader = DataLoader(
-        train_dataset,
-        num_workers=5,
+    worker_count = 0 if os.name == "nt" and n_gpus <= 1 else min(2 if os.name == "nt" else 5, os.cpu_count() or 1)
+    loader_kwargs = dict(
+        num_workers=worker_count,
         shuffle=False,
-        pin_memory=True,
+        pin_memory=torch.cuda.is_available(),
         collate_fn=collate_fn,
         batch_sampler=train_sampler,
-        persistent_workers=True,
-        prefetch_factor=3,
+    )
+    if worker_count > 0:
+        loader_kwargs["persistent_workers"] = True
+        loader_kwargs["prefetch_factor"] = 2 if os.name == "nt" else 3
+    train_loader = DataLoader(
+        train_dataset,
+        **loader_kwargs,
     )
     save_root = "%s/logs_s2_%s_lora_%s" % (hps.data.exp_dir, hps.model.version, hps.train.lora_rank)
     os.makedirs(save_root, exist_ok=True)
@@ -156,7 +167,9 @@ def run(rank, n_gpus, hps):
 
     def model2cuda(net_g, rank):
         if torch.cuda.is_available():
-            net_g = DDP(net_g.cuda(rank), device_ids=[rank], find_unused_parameters=True)
+            net_g = net_g.cuda(rank)
+            if use_ddp:
+                net_g = DDP(net_g, device_ids=[rank], find_unused_parameters=True)
         else:
             net_g = net_g.to(device)
         return net_g
@@ -242,6 +255,8 @@ def run(rank, n_gpus, hps):
                 None,
             )
         scheduler_g.step()
+    if use_ddp and dist.is_initialized():
+        dist.destroy_process_group()
     print("training done")
 
 
@@ -327,22 +342,28 @@ def train_and_evaluate(rank, epoch, hps, nets, optims, schedulers, scaler, loade
 
         global_step += 1
     if epoch % hps.train.save_every_epoch == 0 and rank == 0:
-        if hps.train.if_save_latest == 0:
-            utils.save_checkpoint(
-                net_g,
-                optim_g,
-                hps.train.learning_rate,
-                epoch,
-                os.path.join(save_root, "G_{}.pth".format(global_step)),
-            )
-        else:
-            utils.save_checkpoint(
-                net_g,
-                optim_g,
-                hps.train.learning_rate,
-                epoch,
-                os.path.join(save_root, "G_{}.pth".format(233333333333)),
-            )
+        try:
+            if hps.train.if_save_latest == 0:
+                utils.save_checkpoint(
+                    net_g,
+                    optim_g,
+                    hps.train.learning_rate,
+                    epoch,
+                    os.path.join(save_root, "G_{}.pth".format(global_step)),
+                )
+            else:
+                utils.save_checkpoint(
+                    net_g,
+                    optim_g,
+                    hps.train.learning_rate,
+                    epoch,
+                    os.path.join(save_root, "G_{}.pth".format(233333333333)),
+                )
+        except Exception as e:
+            if logger is not None:
+                logger.warning(f"skip large checkpoint save due to error: {e}")
+            else:
+                print(f"skip large checkpoint save due to error: {e}")
         if rank == 0 and hps.train.if_save_every_weights == True:
             if hasattr(net_g, "module"):
                 ckpt = net_g.module.state_dict()

--- a/GPT_SoVITS/s2_train_v3_lora.py
+++ b/GPT_SoVITS/s2_train_v3_lora.py
@@ -342,28 +342,22 @@ def train_and_evaluate(rank, epoch, hps, nets, optims, schedulers, scaler, loade
 
         global_step += 1
     if epoch % hps.train.save_every_epoch == 0 and rank == 0:
-        try:
-            if hps.train.if_save_latest == 0:
-                utils.save_checkpoint(
-                    net_g,
-                    optim_g,
-                    hps.train.learning_rate,
-                    epoch,
-                    os.path.join(save_root, "G_{}.pth".format(global_step)),
-                )
-            else:
-                utils.save_checkpoint(
-                    net_g,
-                    optim_g,
-                    hps.train.learning_rate,
-                    epoch,
-                    os.path.join(save_root, "G_{}.pth".format(233333333333)),
-                )
-        except Exception as e:
-            if logger is not None:
-                logger.warning(f"skip large checkpoint save due to error: {e}")
-            else:
-                print(f"skip large checkpoint save due to error: {e}")
+        if hps.train.if_save_latest == 0:
+            utils.save_checkpoint(
+                net_g,
+                optim_g,
+                hps.train.learning_rate,
+                epoch,
+                os.path.join(save_root, "G_{}.pth".format(global_step)),
+            )
+        else:
+            utils.save_checkpoint(
+                net_g,
+                optim_g,
+                hps.train.learning_rate,
+                epoch,
+                os.path.join(save_root, "G_{}.pth".format(233333333333)),
+            )
         if rank == 0 and hps.train.if_save_every_weights == True:
             if hasattr(net_g, "module"):
                 ckpt = net_g.module.state_dict()

--- a/GPT_SoVITS/utils.py
+++ b/GPT_SoVITS/utils.py
@@ -69,8 +69,7 @@ def my_save(fea, path):  #####fix issue: torch.save doesn't support chinese path
     name = os.path.basename(path)
     tmp_path = "%s.pth" % (ttime())
     torch.save(fea, tmp_path)
-    os.makedirs(dir, exist_ok=True)
-    os.replace(tmp_path, "%s/%s" % (dir, name))
+    shutil.move(tmp_path, "%s/%s" % (dir, name))
 
 
 def save_checkpoint(model, optimizer, learning_rate, iteration, checkpoint_path):

--- a/GPT_SoVITS/utils.py
+++ b/GPT_SoVITS/utils.py
@@ -69,7 +69,8 @@ def my_save(fea, path):  #####fix issue: torch.save doesn't support chinese path
     name = os.path.basename(path)
     tmp_path = "%s.pth" % (ttime())
     torch.save(fea, tmp_path)
-    shutil.move(tmp_path, "%s/%s" % (dir, name))
+    os.makedirs(dir, exist_ok=True)
+    os.replace(tmp_path, "%s/%s" % (dir, name))
 
 
 def save_checkpoint(model, optimizer, learning_rate, iteration, checkpoint_path):


### PR DESCRIPTION
## Summary / 摘要
- avoid forcing `mp.spawn` and DDP for Windows single-GPU v3 LoRA training
- reduce DataLoader worker overhead for Windows single-GPU runs

- 避免在 Windows 单卡的 v3 LoRA 训练里强制使用 `mp.spawn` 和 DDP
- 降低 Windows 单卡场景下 DataLoader 的额外开销

## Related Issues / 相关问题
- related to #399 and #423
- these reports are highly consistent with the Windows + RTX 4060 + memory-pressure symptoms reproduced and verified locally

- 关联问题：#399 和 #423
- 这些反馈与我们本地复现并验证到的 Windows + RTX 4060 + 内存压力症状高度一致

## Root Cause / 根因
The final v3 LoRA stage was tuned for multi-process training. On Windows single-GPU setups this created avoidable process and memory pressure.

v3 LoRA 的最后训练阶段原本更偏向多进程训练。在 Windows 单卡环境下，这会带来额外且没有必要的进程与内存压力。

## Validation / 验证
- `python -m py_compile GPT_SoVITS/s2_train_v3_lora.py`

- 已通过 `python -m py_compile GPT_SoVITS/s2_train_v3_lora.py` 做基础语法校验
