### PR TITLE
Fix: handle empty bert_list and align BERT/phones length

### DIFF
--- a/api.py
+++ b/api.py
@@ -599,12 +599,37 @@ def get_phones_and_bert(text, language, version, final=False):
         phones_list.append(phones)
         norm_text_list.append(norm_text)
         bert_list.append(bert)
-    bert = torch.cat(bert_list, dim=1)
+    # Fix: handle empty bert_list to avoid torch.cat() crash
+    if bert_list:
+        bert = torch.cat(bert_list, dim=1)
+    else:
+        phones_total = sum(phones_list, []) if phones_list else []
+        bert = torch.zeros(
+            (1024, max(len(phones_total), 1)),
+            dtype=torch.float16 if is_half == True else torch.float32,
+        ).to(device)
     phones = sum(phones_list, [])
     norm_text = "".join(norm_text_list)
 
     if not final and len(phones) < 6:
         return get_phones_and_bert("." + text, language, version, final=True)
+
+    # Fix: align BERT feature length with phones length to avoid dimension mismatch
+    # e.g., RuntimeError: tensor a (44) must match tensor b (45) at non-singleton dimension 1
+    phones_len = len(phones)
+    bert_len = bert.shape[1]
+    if phones_len != bert_len:
+        import torch.nn.functional as F
+        logger.warning(f"[TTS] BERT length mismatch: phones={phones_len}, bert={bert_len}, adjusting...")
+        bert = bert.transpose(1, 2)  # (1024, seq) -> (seq, 1024)
+        if phones_len > bert_len:
+            # Interpolate to enlarge
+            bert = F.interpolate(bert.unsqueeze(0), size=phones_len, mode='linear', align_corners=False)
+        else:
+            # Truncate excess
+            bert = bert[:, :phones_len, :]
+        bert = bert.squeeze(0).transpose(0, 1)  # (seq, 1024) -> (1024, seq)
+        bert = bert.to(device)
 
     return phones, bert.to(torch.float16 if is_half == True else torch.float32), norm_text
 


### PR DESCRIPTION
📋 修改摘要
Bug 1：`torch.cat()` 空列表崩溃
错误信息：
RuntimeError: torch.cat(): expected a non-empty list of Tensors

根因：当 `LangSegmenter.getTexts()` 对某些文本返回空结果时，`bert_list` 变为空列表，导致 `torch.cat([])` 崩溃。

修复：在调用 `torch.cat()` 前检查 `bert_list` 是否为空，若为空则创建零张量作为降级处理。
Bug 2：BERT 特征与 Phones 长度不匹配
错误信息：
RuntimeError: The size of tensor a (44) must match the size of tensor b (45)
at non-singleton dimension 1

根因：BERT 特征序列长度与音素（phones）序列长度不一致（如 BERT 返回 45 个特征，但 phones 只有 44 个）。

修复：在返回前检测长度差异，使用线性插值放大或裁剪对齐。
修改位置
`api.py` → `get_phones_and_bert()` 函数（第 602-632 行）