### PR TITLE
Fix s1_train DDP crash on Windows single-GPU (sm_120 / Blackwell)

### DIFF
--- a/GPT_SoVITS/AR/data/bucket_sampler.py
+++ b/GPT_SoVITS/AR/data/bucket_sampler.py
@@ -36,14 +36,16 @@ class DistributedBucketSampler(Sampler[T_co]):
         drop_last: bool = False,
         batch_size: int = 32,
     ) -> None:
+        # Patched: support non-DDP single-GPU runs (Lightning strategy='auto' on
+        # Windows). When the distributed group isn't initialized, fall back to
+        # a single-replica configuration.
+        _dist_ready = (
+            dist.is_available() and dist.is_initialized() and torch.cuda.is_available()
+        )
         if num_replicas is None:
-            if not dist.is_available():
-                raise RuntimeError("Requires distributed package to be available")
-            num_replicas = dist.get_world_size() if torch.cuda.is_available() else 1
+            num_replicas = dist.get_world_size() if _dist_ready else 1
         if rank is None:
-            if not dist.is_available():
-                raise RuntimeError("Requires distributed package to be available")
-            rank = dist.get_rank() if torch.cuda.is_available() else 0
+            rank = dist.get_rank() if _dist_ready else 0
             if torch.cuda.is_available():
                 torch.cuda.set_device(rank)
         if rank >= num_replicas or rank < 0:

--- a/GPT_SoVITS/s1_train.py
+++ b/GPT_SoVITS/s1_train.py
@@ -114,12 +114,18 @@ def main(args):
         # val_check_interval=9999999999999999999999,###不要验证
         # check_val_every_n_epoch=None,
         limit_val_batches=0,
-        devices=-1 if torch.cuda.is_available() else 1,
+        # On Windows, force single-device (no DDP) — see strategy comment below.
+        # Non-Windows preserves original "all GPUs" behaviour.
+        devices=(1 if platform.system() == "Windows" else -1) if torch.cuda.is_available() else 1,
         benchmark=False,
         fast_dev_run=False,
-        strategy=DDPStrategy(process_group_backend="nccl" if platform.system() != "Windows" else "gloo")
-        if torch.cuda.is_available()
-        else "auto",
+        # On Windows, DDPStrategy with the gloo backend crashes with native
+        # access violations on Blackwell (sm_120) / CUDA 12.8. Lightning's
+        # "auto" strategy picks `single_device` for 1 GPU which avoids DDP
+        # entirely. Non-Windows behaviour is preserved (NCCL DDP).
+        strategy="auto"
+        if (platform.system() == "Windows" or not torch.cuda.is_available())
+        else DDPStrategy(process_group_backend="nccl"),
         precision=config["train"]["precision"],
         logger=logger,
         num_sanity_val_steps=0,


### PR DESCRIPTION
## Summary

On Windows + single GPU + CUDA 12.8 + PyTorch 2.7+ on Blackwell (`sm_120`) hardware, `s1_train.py` crashes with a native access violation (`exit code 3221225477` / `0xC0000005`) shortly after `pytorch_lightning`'s `Trainer.fit()` is called, before the first batch runs.

## Repro

```
OS:      Windows 11
GPU:     RTX 5090 (compute capability 12.0, sm_120, Blackwell)
CUDA:    12.8
PyTorch: 2.11.0+cu128
Lightning: 2.6.1
```

Run any voice training through the standard webui / `s1_train.py` pipeline. The s1 (GPT) stage prints model summary, dataloader warnings, then exits with `3221225477` and no Python traceback.

## Root cause

`s1_train.py` constructs the Trainer with `DDPStrategy(backend="gloo")` on Windows, regardless of GPU count. The `gloo` + `sm_120` + CUDA 12.8 combination has a known incompatibility — confirmed by an independent PyTorch forum report titled [\"[Solved] RTX 5090 (sm_120) Training Segfault — DDP Was the Cause\"](https://discuss.pytorch.org/t/solved-rtx-5090-sm-120-training-segfault-ddp-was-the-cause/224584) — and produces a native crash inside Lightning's training-loop setup.

For a single GPU, DDP brings only process-management overhead and no parallelism benefit. Letting Lightning pick \`strategy=\"auto\"\` selects \`single_device\`, avoiding DDP entirely.

## Changes

Two narrowly-scoped patches, both Windows-conditional:

### `GPT_SoVITS/s1_train.py`

* On Windows, use `strategy=\"auto\"` and `devices=1` instead of `DDPStrategy(\"gloo\")` + `devices=-1`.
* **Linux / macOS behaviour is unchanged** — still NCCL DDP across all GPUs.

### `GPT_SoVITS/AR/data/bucket_sampler.py`

* `DistributedBucketSampler` previously assumed a distributed group was always initialized. With `strategy=\"auto\"` on a single GPU, Lightning does not initialize the group, so `dist.get_world_size()` raises.
* Now: if the group is not initialized, fall back to a single-replica configuration (`num_replicas=1`, `rank=0`).
* **Defensive change** — behaviour is unchanged whenever DDP is initialized.

## Testing

* Windows 11 + RTX 5090 (sm_120) + CUDA 12.8 + PyTorch 2.11+cu128 + Lightning 2.6.1
* 15-epoch v4 LoRA training on a 30-min Chinese dataset (\`batch_size=4\`, \`lora_rank=32\`)
* Pre-patch: crashes with \`3221225477\` after model load, no checkpoints saved.
* Post-patch: training completes cleanly through all 15 epochs, weights saved to \`GPT_weights_v4/\` as expected.

## Closes

Closes #2626 (\"\`RuntimeError: makeDeviceForHostname(): unsupported gloo device\`\" — same root cause).