### PR TITLE
[AMD]Add ROCm Docker support for AMD GPUs (RDNA3/RDNA4)

### DIFF
--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -1,0 +1,52 @@
+ARG ROCM_VERSION=7.2.3
+ARG PYTORCH_IMAGE=rocm/pytorch:rocm${ROCM_VERSION}_ubuntu24.04_py3.12_pytorch_release_2.9.1
+
+FROM ${PYTORCH_IMAGE}
+
+LABEL maintainer="AMD Community"
+LABEL description="GPT-SoVITS with ROCm support (RDNA3/RDNA4)"
+
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        git ffmpeg unzip wget cmake make gcc g++ && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace/GPT-SoVITS
+
+COPY requirements.txt extra-req.txt /workspace/GPT-SoVITS/
+
+RUN pip install --no-cache-dir soundfile && \
+    sed 's/onnxruntime-gpu.*/onnxruntime_migraphx/' requirements.txt > /tmp/requirements-rocm.txt && \
+    pip install --no-cache-dir -r extra-req.txt --no-deps && \
+    pip install --no-cache-dir -r /tmp/requirements-rocm.txt \
+        -f https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2.3/ && \
+    pip install --no-cache-dir "starlette>=0.40.0,<1.0.0" && \
+    python -c "import nltk; nltk.download('averaged_perceptron_tagger_eng'); nltk.download('averaged_perceptron_tagger'); nltk.download('cmudict')" && \
+    rm -rf /tmp/* /root/.cache/pip
+
+ARG HF_SOURCE=https://huggingface.co/XXXXRT/GPT-SoVITS-Pretrained/resolve/main
+RUN wget -q "${HF_SOURCE}/pretrained_models.zip" && \
+    unzip -q -o pretrained_models.zip -d GPT_SoVITS && \
+    rm pretrained_models.zip && \
+    wget -q "${HF_SOURCE}/G2PWModel.zip" && \
+    unzip -q -o G2PWModel.zip -d GPT_SoVITS/text && \
+    rm G2PWModel.zip && \
+    wget -q "${HF_SOURCE}/nltk_data.zip" -O nltk_data.zip && \
+    PY_PREFIX=$(python -c "import sys; print(sys.prefix)") && \
+    unzip -q -o nltk_data.zip -d "$PY_PREFIX" && \
+    rm nltk_data.zip && \
+    wget -q "${HF_SOURCE}/open_jtalk_dic_utf_8-1.11.tar.gz" && \
+    PYOPENJTALK_DIR=$(python -c "import os, pyopenjtalk; print(os.path.dirname(pyopenjtalk.__file__))") && \
+    tar -xzf open_jtalk_dic_utf_8-1.11.tar.gz -C "$PYOPENJTALK_DIR" && \
+    rm open_jtalk_dic_utf_8-1.11.tar.gz
+
+COPY . /workspace/GPT-SoVITS
+
+ENV PYTHONPATH="/workspace/GPT-SoVITS:/workspace/GPT-SoVITS/GPT_SoVITS"
+ENV ROCBLAS_USE_HIPBLASLT=0
+
+EXPOSE 9871 9872 9873 9874 9880
+
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -176,6 +176,58 @@ To run a specific service with Docker Compose, use:
 docker compose run --service-ports <GPT-SoVITS-CU126-Lite|GPT-SoVITS-CU128-Lite|GPT-SoVITS-CU126|GPT-SoVITS-CU128>
 ```
 
+#### Running with AMD ROCm (Docker)
+
+GPT-SoVITS supports AMD GPUs via ROCm. Tested on RDNA4 (Radeon AI PRO R9700 / gfx1201) with ROCm 7.2.3.
+
+**Requirements:**
+- AMD GPU with ROCm support (RDNA3 / RDNA4)
+- ROCm drivers installed on the host
+- Docker with GPU passthrough (`/dev/kfd` and `/dev/dri`)
+
+**Quick start:**
+
+```bash
+docker compose -f docker-compose-rocm.yaml run --service-ports GPT-SoVITS-ROCm
+```
+
+**Or build and run manually:**
+
+```bash
+docker build -f Dockerfile.rocm -t gpt-sovits:rocm .
+docker run -it --rm \
+  --device=/dev/kfd --device=/dev/dri \
+  --group-add video --group-add render \
+  -e ROCBLAS_USE_HIPBLASLT=0 \
+  -e is_half=true \
+  --shm-size=16g \
+  -p 9880:9880 -p 9874:9874 \
+  gpt-sovits:rocm
+```
+
+Then inside the container:
+
+```bash
+python webui.py
+```
+
+**Notes:**
+- `ROCBLAS_USE_HIPBLASLT=0` is required for RDNA4 (gfx1201) stability
+- RDNA3 (gfx1100/gfx1101) users may not need this env var
+- The first inference run will be slower due to MIOpen kernel auto-tuning; subsequent runs are faster
+- `onnxruntime-gpu` is replaced with [`onnxruntime_migraphx`](https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2.3/) which provides `ROCMExecutionProvider` and `MIGraphXExecutionProvider` for GPU-accelerated ONNX inference
+
+**Tested environment:**
+
+| Component | Version |
+|-----------|---------|
+| GPU | AMD Radeon AI PRO R9700 (gfx1201 / RDNA4, 32GB) |
+| ROCm | 7.2.3 |
+| PyTorch | 2.9.1+rocm7.2.3 |
+| Python | 3.12 |
+| Model | GPT-SoVITS v2 pretrained |
+| Inference | ✅ Passed (fp16) |
+
 #### Building the Docker Image Locally
 
 If you want to build the image yourself, use:

--- a/docker-compose-rocm.yaml
+++ b/docker-compose-rocm.yaml
@@ -1,0 +1,30 @@
+version: "3.8"
+
+services:
+  GPT-SoVITS-ROCm:
+    build:
+      context: .
+      dockerfile: Dockerfile.rocm
+    image: gpt-sovits:rocm7.2.3
+    container_name: GPT-SoVITS-ROCm
+    ports:
+      - "9871:9871"
+      - "9872:9872"
+      - "9873:9873"
+      - "9874:9874"
+      - "9880:9880"
+    volumes:
+      - .:/workspace/GPT-SoVITS
+    environment:
+      - is_half=true
+      - ROCBLAS_USE_HIPBLASLT=0
+    devices:
+      - /dev/kfd
+      - /dev/dri
+    group_add:
+      - video
+      - render
+    tty: true
+    stdin_open: true
+    shm_size: "16g"
+    restart: unless-stopped


### PR DESCRIPTION
## Summary

- Add `Dockerfile.rocm` and `docker-compose-rocm.yaml` for AMD ROCm GPU support
- Add ROCm Docker instructions to README
- Verified inference on RDNA4 (Radeon AI PRO R9700 / gfx1201) with ROCm 7.2.3

## Changes

| File | Description |
|------|-------------|
| `Dockerfile.rocm` | ROCm build based on `rocm/pytorch:rocm7.2.3`, with `onnxruntime_migraphx` for GPU-accelerated ONNX |
| `docker-compose-rocm.yaml` | One-command launch with `/dev/kfd` + `/dev/dri` passthrough |
| `README.md` | Added ROCm Docker section with quick start, manual build, and notes |

## Key design decisions

- Base image: `rocm/pytorch:rocm7.2.3_ubuntu24.04_py3.12_pytorch_release_2.9.1` (official AMD image)
- `onnxruntime-gpu` → `onnxruntime_migraphx` (from [repo.radeon.com](https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2.3/))
- `ROCBLAS_USE_HIPBLASLT=0` set by default (required for RDNA4 stability)
- `starlette<1.0.0` pinned to work around [#2762](https://github.com/RVC-Boss/GPT-SoVITS/issues/2762)
- No `HSA_OVERRIDE_GFX_VERSION` — gfx1201 is natively supported in ROCm 7.2+

## Test

| Component | Version |
|-----------|---------|
| GPU | AMD Radeon AI PRO R9700 (gfx1201 / RDNA4, 32GB) |
| ROCm | 7.2.3 |
| PyTorch | 2.9.1+rocm7.2.3 |
| Python | 3.12 |

- ✅ Model load (GPT + SoVITS v2 + BERT + CNHuBERT) on GPU with fp16
- ✅ TTS inference: 14.5s audio @ 32kHz generated successfully
- ✅ WebUI (`webui.py`) launches and serves on port 9874
- ✅ `onnxruntime_migraphx` provides `MIGraphXExecutionProvider`
- MIOpen `GemmFwdRest` workspace warnings on first run are normal (kernel auto-tuning fallback)

local test code
```python
import sys, os, time
os.environ["is_half"] = "True"
sys.path.insert(0, "/root/GPT-SoVITS")
sys.path.insert(0, "/root/GPT-SoVITS/GPT_SoVITS")

import torch
print(f"GPU: {torch.cuda.get_device_name(0)} (gfx1201)")
print(f"torch: {torch.__version__}")
print(f"HIP: {torch.version.hip}")

import torchaudio
import soundfile as sf_lib
_orig_load = torchaudio.load
def _patched_load(filepath, *args, **kwargs):
    data, sr = sf_lib.read(filepath, dtype="float32")
    t = torch.from_numpy(data)
    if t.ndim == 1:
        t = t.unsqueeze(0)
    else:
        t = t.T
    return t, sr
torchaudio.load = _patched_load

from GPT_SoVITS.TTS_infer_pack.TTS import TTS, TTS_Config

config_dict = {
    "custom": {
        "device": "cuda:0",
        "is_half": True,
        "version": "v2",
        "t2s_weights_path": "GPT_SoVITS/pretrained_models/gsv-v2final-pretrained/s1bert25hz-5kh-longer-epoch=12-step=369668.ckpt",
        "vits_weights_path": "GPT_SoVITS/pretrained_models/gsv-v2final-pretrained/s2G2333k.pth",
        "cnhuhbert_base_path": "GPT_SoVITS/pretrained_models/chinese-hubert-base",
        "bert_base_path": "GPT_SoVITS/pretrained_models/chinese-roberta-wwm-ext-large",
    }
}

tts_config = TTS_Config(config_dict)
print(f"Config device: {tts_config.device}, is_half: {tts_config.is_half}")

tts_pipeline = TTS(tts_config)
print("TTS pipeline initialized on GPU")

inputs = {
    "text": "Hello, this is a test of GPT SoVITS running on AMD ROCm.",
    "text_lang": "en",
    "ref_audio_path": "/tmp/ref_audio.wav",
    "prompt_text": "This is a reference audio sample.",
    "prompt_lang": "en",
    "top_k": 5,
    "top_p": 1.0,
    "temperature": 1.0,
    "text_split_method": "cut0",
    "speed_factor": 1.0,
    "split_bucket": False,
    "return_fragment": False,
    "fragment_interval": 0.3,
}

print("Starting inference...")
t0 = time.time()
try:
    results = list(tts_pipeline.run(inputs))
    t1 = time.time()
    for i, (sr, audio) in enumerate(results):
        print(f"  Chunk {i}: sr={sr}, shape={audio.shape}, duration={audio.shape[-1]/sr:.2f}s")
    print(f"Inference time: {t1-t0:.2f}s")
    
    import soundfile as sf
    sr, audio = results[0]
    sf.write("/tmp/gpt_sovits_test_output.wav", audio, sr)
    fsize = os.path.getsize("/tmp/gpt_sovits_test_output.wav")
    print(f"Saved: /tmp/gpt_sovits_test_output.wav ({fsize} bytes)")
    print("=== INFERENCE PASSED on gfx1201 + ROCm 7.2.3 ===")
except Exception as e:
    t1 = time.time()
    print(f"INFERENCE FAILED after {t1-t0:.2f}s: {type(e).__name__}: {e}")
    import traceback
    traceback.print_exc()
```
output
```shell
GPU: AMD Radeon Graphics (gfx1201)
torch: 2.9.1+rocm7.2.3.gitebc02d69
HIP: 7.2.53211-c2d9476115
Config device: cuda:0, is_half: True
Loading Text2Semantic weights from GPT_SoVITS/pretrained_models/gsv-v2final-pretrained/s1bert25hz-5kh-longer-epoch=12-step=369668.ckpt
Loading VITS weights from GPT_SoVITS/pretrained_models/gsv-v2final-pretrained/s2G2333k.pth. <All keys matched successfully>
Loading BERT weights from GPT_SoVITS/pretrained_models/chinese-roberta-wwm-ext-large
Loading CNHuBERT weights from GPT_SoVITS/pretrained_models/chinese-hubert-base
TTS pipeline initialized on GPU
Starting inference...
Set seed to 1855520474
Parallel Inference Mode Enabled
Bucket Processing Mode Disabled
Actual Input Reference Text: This is a reference audio sample.
############ Segment Text ############
Actual Input Target Text:
Hello, this is a test of GPT SoVITS running on AMD ROCm.
Actual Input Target Text (after sentence segmentation):
['Hello, this is a test of GPT SoVITS running on AMD ROCm.']
############ Extract Text BERT Features ############
100%|██████████| 1/1 [00:00<00:00, 888.81it/s]
############ 推理 ############
Processed text from the frontend (per sentence): ['Hello, this is a test of G P T So V I T S running on A M D R O Cm.']
############ Predict Semantic Token ############
T2S Decoding EOS [89 -> 444]
############ Synthesize Audio ############
Parallel Synthesis in Progress...
16.085	0.003	1.978	23.685
  Chunk 0: sr=32000, shape=(462720,), duration=14.46s
Inference time: 42.11s
Saved: /tmp/gpt_sovits_test_output.wav (925484 bytes)
=== INFERENCE PASSED on gfx1201 + ROCm 7.2.3 ===
```
webui
<img width="916" height="527" alt="Screenshot 2026-05-29 160554" src="https://github.com/user-attachments/assets/690c4c9a-0b78-475b-ab19-8f6dbcf6e895" />
