### PR TITLE
fix(asr): cache FunASR models and skip redundant downloads

### DIFF
--- a/tools/asr/funasr_asr.py
+++ b/tools/asr/funasr_asr.py
@@ -22,51 +22,55 @@ def only_asr(input_file, language):
 
 
 def create_model(language="zh"):
+    if language in funasr_models:
+        return funasr_models[language]
+
     if language == "zh":
         path_vad = "tools/asr/models/speech_fsmn_vad_zh-cn-16k-common-pytorch"
         path_punc = "tools/asr/models/punc_ct-transformer_zh-cn-common-vocab272727-pytorch"
         path_asr = "tools/asr/models/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch"
-        snapshot_download(
-            "iic/speech_fsmn_vad_zh-cn-16k-common-pytorch",
-            local_dir="tools/asr/models/speech_fsmn_vad_zh-cn-16k-common-pytorch",
-        )
-        snapshot_download(
-            "iic/punc_ct-transformer_zh-cn-common-vocab272727-pytorch",
-            local_dir="tools/asr/models/punc_ct-transformer_zh-cn-common-vocab272727-pytorch",
-        )
-        snapshot_download(
-            "iic/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch",
-            local_dir="tools/asr/models/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch",
-        )
+        if not os.path.isdir(path_vad):
+            snapshot_download(
+                "iic/speech_fsmn_vad_zh-cn-16k-common-pytorch",
+                local_dir=path_vad,
+            )
+        if not os.path.isdir(path_punc):
+            snapshot_download(
+                "iic/punc_ct-transformer_zh-cn-common-vocab272727-pytorch",
+                local_dir=path_punc,
+            )
+        if not os.path.isdir(path_asr):
+            snapshot_download(
+                "iic/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch",
+                local_dir=path_asr,
+            )
         model_revision = "v2.0.4"
         vad_model_revision = punc_model_revision = "v2.0.4"
     elif language == "yue":
         path_asr = "tools/asr/models/speech_UniASR_asr_2pass-cantonese-CHS-16k-common-vocab1468-tensorflow1-online"
-        snapshot_download(
-            "iic/speech_UniASR_asr_2pass-cantonese-CHS-16k-common-vocab1468-tensorflow1-online",
-            local_dir="tools/asr/models/speech_UniASR_asr_2pass-cantonese-CHS-16k-common-vocab1468-tensorflow1-online",
-        )
+        if not os.path.isdir(path_asr):
+            snapshot_download(
+                "iic/speech_UniASR_asr_2pass-cantonese-CHS-16k-common-vocab1468-tensorflow1-online",
+                local_dir=path_asr,
+            )
         path_vad = path_punc = None
         vad_model_revision = punc_model_revision = ""
         model_revision = "master"
     else:
         raise ValueError(f"{language} is not supported")
 
-    if language in funasr_models:
-        return funasr_models[language]
-    else:
-        model = AutoModel(
-            model=path_asr,
-            model_revision=model_revision,
-            vad_model=path_vad,
-            vad_model_revision=vad_model_revision,
-            punc_model=path_punc,
-            punc_model_revision=punc_model_revision,
-        )
-        print(f"FunASR 模型加载完成: {language.upper()}")
+    model = AutoModel(
+        model=path_asr,
+        model_revision=model_revision,
+        vad_model=path_vad,
+        vad_model_revision=vad_model_revision,
+        punc_model=path_punc,
+        punc_model_revision=punc_model_revision,
+    )
+    print(f"FunASR 模型加载完成: {language.upper()}")
 
-        funasr_models[language] = model
-        return model
+    funasr_models[language] = model
+    return model
 
 
 def execute_asr(input_folder, output_folder, model_size, language):


### PR DESCRIPTION
## Summary

Improve `tools/asr/funasr_asr.py` `create_model()` behavior:

- Return the cached `AutoModel` immediately when the language was already loaded (`funasr_models`).
- Call `snapshot_download()` only if the corresponding model directory does not exist, instead of on every `create_model()` invocation.

This reduces repeated ModelScope downloads and avoids reloading FunASR weights when processing multiple files or repeated ASR calls (e.g. WebUI batch ASR, HTTP ASR services).

## Motivation

The previous flow always ran `snapshot_download` before checking the in-memory cache, which is slow and unnecessary after models are already on disk.

## Test plan

- [ ] With models already under `tools/asr/models/`, run Chinese ASR twice (WebUI or `only_asr`); second run should not re-download.
- [ ] Fresh install / empty model dir: first run still downloads models successfully.
- [ ] Cantonese (`yue`) path: same skip-download behavior when directory exists.