### PR TITLE
fix(install): support libstdcxx-ng on GCC 16+ hosts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -196,8 +196,14 @@ if [ "$(uname)" != "Darwin" ]; then
         echo -e "${INFO}Detected GCC Version: $gcc_major_version"
         echo -e "${INFO}Skip Installing GCC & G++ From Conda-Forge"
         echo -e "${INFO}Installing libstdcxx-ng From Conda-Forge"
-        run_conda_quiet "libstdcxx-ng>=$gcc_major_version"
-        echo -e "${SUCCESS}libstdcxx-ng=$gcc_major_version Installed..."
+        # Arch GCC 16+: conda 尚无 libstdcxx-ng>=16，装最新版即可
+        if [ "$gcc_major_version" -gt 15 ]; then
+            run_conda_quiet libstdcxx-ng
+            echo -e "${SUCCESS}libstdcxx-ng (latest) Installed..."
+        else
+            run_conda_quiet "libstdcxx-ng>=$gcc_major_version"
+            echo -e "${SUCCESS}libstdcxx-ng=$gcc_major_version Installed..."
+        fi
     fi
 else
     if ! xcode-select -p &>/dev/null; then


### PR DESCRIPTION
## Summary

On Linux with system GCC 11+ (conda skips bundling gcc/g++), install `libstdcxx-ng` from conda-forge to match the C++ runtime.

When the system GCC major version is newer than what conda-forge pins (currently > 15, e.g. GCC 16 on Arch), install the latest `libstdcxx-ng` instead of `libstdcxx-ng>=N`, which may not be published yet.

## Test plan

- [ ] Linux, GCC 16+: `bash install.sh --device ...` completes the libstdcxx-ng step without conda solver errors
- [ ] Linux, GCC 11–15: still installs `libstdcxx-ng>=$gcc_major_version`
- [ ] macOS path unchanged