### PR TITLE
feat: training data browsing API + relax ref-audio duration limit + emotion annotation field

### DIFF
--- a/GPT_SoVITS/TTS_infer_pack/TTS.py
+++ b/GPT_SoVITS/TTS_infer_pack/TTS.py
@@ -813,8 +813,9 @@ class TTS:
         )
         with torch.no_grad():
             wav16k, sr = librosa.load(ref_wav_path, sr=16000)
-            if wav16k.shape[0] > 160000 or wav16k.shape[0] < 48000:
-                raise OSError(i18n("参考音频在3~10秒范围外，请更换！"))
+            ref_duration = wav16k.shape[0] / 16000
+            if ref_duration < 3 or ref_duration > 10:
+                print(f"[Warning] Reference audio duration {ref_duration:.1f}s is outside the recommended 3~10s range, proceeding anyway")
             wav16k = torch.from_numpy(wav16k)
             zero_wav_torch = torch.from_numpy(zero_wav)
             wav16k = wav16k.to(self.configs.device)

--- a/GPT_SoVITS/inference_webui.py
+++ b/GPT_SoVITS/inference_webui.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 按中英混合识别
 按日英混合识别
@@ -27,6 +29,7 @@ import re
 import sys
 import traceback
 import warnings
+from pathlib import Path
 
 import torch
 import torchaudio
@@ -851,9 +854,9 @@ def get_tts_wav(
     if not ref_free:
         with torch.no_grad():
             wav16k, sr = librosa.load(ref_wav_path, sr=16000)
-            if wav16k.shape[0] > 160000 or wav16k.shape[0] < 48000:
-                gr.Warning(i18n("参考音频在3~10秒范围外，请更换！"))
-                raise OSError(i18n("参考音频在3~10秒范围外，请更换！"))
+            ref_duration = wav16k.shape[0] / 16000
+            if ref_duration < 3 or ref_duration > 10:
+                gr.Warning(i18n(f"参考音频时长 {ref_duration:.1f} 秒，超出推荐的 3~10 秒范围，可能影响合成质量"))
             wav16k = torch.from_numpy(wav16k)
             if is_half == True:
                 wav16k = wav16k.half().to(device)
@@ -1202,6 +1205,136 @@ def html_left(text, label="p"):
                 </div>"""
 
 
+# ===================== 训练角色选择 / 训练样本浏览 辅助函数 =====================
+def scan_model_names() -> list[str]:
+    """扫描 logs/ 目录获取所有训练角色名（含 2-name2text.txt 的子目录）。"""
+    from config import exp_root
+    import os
+
+    root = Path(exp_root)
+    if not root.exists():
+        return []
+    return sorted(
+        [
+            d.name
+            for d in root.iterdir()
+            if d.is_dir() and (d / "2-name2text.txt").exists()
+        ]
+    )
+
+
+def _read_name2text_for_webui(logs_dir: Path) -> dict[str, dict[str, str]]:
+    """读取 2-name2text.txt（WebUI 版，与 api_v2.py 的 _read_name2text 逻辑一致）。
+
+    返回 {wav_name: {"text": ..., "lang": ...}}，同时以 stem 建索引。
+    """
+    path = logs_dir / "2-name2text.txt"
+    if not path.exists():
+        return {}
+    output: dict[str, dict[str, str]] = {}
+    for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+        parts = line.split("\t")
+        if len(parts) < 4:
+            continue
+        wav_name = parts[0].strip()
+        text = parts[3].strip()
+        if wav_name and text:
+            entry = {"text": text, "lang": "zh"}
+            output[wav_name] = entry
+            output[Path(wav_name).stem] = entry
+    return output
+
+
+def on_model_name_change(model_name: str):
+    """模型名变化时，加载该模型的训练样本列表到下拉框与预览播放器。"""
+    if not model_name:
+        return gr.Dropdown(choices=[], value=""), gr.Audio(value=None)
+    from config import exp_root
+
+    logs_dir = Path(exp_root) / model_name
+    wav_dir = logs_dir / "5-wav32k"
+    samples: list[tuple[str, str]] = []
+    if wav_dir.exists():
+        name2text = _read_name2text_for_webui(logs_dir)
+        for f in sorted(wav_dir.iterdir()):
+            if f.is_file() and f.suffix.lower() in (".wav", ".mp3", ".flac"):
+                text = name2text.get(f.name, {}).get("text", "") or name2text.get(f.stem, {}).get("text", "")
+                label = f"{f.name}" + (f" | {text[:30]}" if text else "")
+                samples.append((label, str(f)))
+    choices = [s[0] for s in samples]
+    value = samples[0][0] if samples else ""
+    audio = samples[0][1] if samples else None
+    return gr.Dropdown(choices=choices, value=value), gr.Audio(value=audio)
+
+
+def on_ref_sample_change(sample_label: str, model_name: str):
+    """训练样本选择变化时，更新预览播放器。"""
+    if not sample_label or not model_name:
+        return gr.Audio(value=None)
+    from config import exp_root
+
+    wav_name = sample_label.split(" | ")[0]
+    audio_path = Path(exp_root) / model_name / "5-wav32k" / wav_name
+    return gr.Audio(value=str(audio_path) if audio_path.exists() else None)
+
+
+def on_apply_sample(sample_label: str, model_name: str):
+    """应用选中样本：写入参考音频路径和参考文本。"""
+    if not sample_label or not model_name:
+        return None, "", gr.Dropdown()
+    from config import exp_root
+
+    wav_name = sample_label.split(" | ")[0]
+    audio_path = Path(exp_root) / model_name / "5-wav32k" / wav_name
+    logs_dir = Path(exp_root) / model_name
+    name2text = _read_name2text_for_webui(logs_dir)
+    text = name2text.get(wav_name, {}).get("text", "") or name2text.get(Path(wav_name).stem, {}).get("text", "")
+    return (str(audio_path) if audio_path.exists() else None), text, gr.Dropdown()
+
+
+def _scan_model_weights_for_webui() -> dict[str, dict[str, list[str]]]:
+    """扫描权重目录（WebUI 版），按 exp_name 分组。"""
+    from config import GPT_weight_root, SoVITS_weight_root
+
+    grouped: dict[str, dict[str, list[str]]] = {}
+    for root in GPT_weight_root:
+        root_path = Path(root)
+        if not root_path.exists():
+            continue
+        for f in root_path.iterdir():
+            if f.is_file() and f.suffix == ".ckpt":
+                name = re.split(r"-e\d+", f.stem, flags=re.IGNORECASE)[0]
+                grouped.setdefault(name, {"gpt": [], "sovits": []})
+                grouped[name]["gpt"].append(f"{root}/{f.name}")
+    for root in SoVITS_weight_root:
+        root_path = Path(root)
+        if not root_path.exists():
+            continue
+        for f in root_path.iterdir():
+            if f.is_file() and f.suffix == ".pth":
+                name = re.split(r"_e\d+_s\d+", f.stem, flags=re.IGNORECASE)[0]
+                grouped.setdefault(name, {"gpt": [], "sovits": []})
+                grouped[name]["sovits"].append(f"{root}/{f.name}")
+    return grouped
+
+
+def on_auto_select_weights(model_name: str):
+    """根据模型名自动匹配并选择最佳 GPT/SoVITS 权重。
+
+    仅返回 Dropdown 的 value；真正的权重切换由已绑定的
+    GPT_dropdown.change / SoVITS_dropdown.change 在 value 变化时自动触发。
+    （change_sovits_weights 是生成器，手动消费会丢失对其它组件的更新，故不直接调用。）
+    """
+    if not model_name:
+        return gr.Dropdown(), gr.Dropdown()
+    weights = _scan_model_weights_for_webui()
+    model_weights = weights.get(model_name, {"gpt": [], "sovits": []})
+    # 选择最高 epoch 的权重（按字符串排序后取末尾）
+    gpt_best = sorted(model_weights["gpt"])[-1] if model_weights["gpt"] else None
+    sovits_best = sorted(model_weights["sovits"])[-1] if model_weights["sovits"] else None
+    return gr.Dropdown(value=gpt_best), gr.Dropdown(value=sovits_best)
+
+
 with gr.Blocks(title="GPT-SoVITS WebUI", analytics_enabled=False, js=js, css=css) as app:
     gr.HTML(
         top_html.format(
@@ -1229,9 +1362,39 @@ with gr.Blocks(title="GPT-SoVITS WebUI", analytics_enabled=False, js=js, css=css
             )
             refresh_button = gr.Button(i18n("刷新模型路径"), variant="primary", scale=14)
             refresh_button.click(fn=change_choices, inputs=[], outputs=[SoVITS_dropdown, GPT_dropdown])
+        # ===== 新增：训练角色选择区域 =====
+        with gr.Group():
+            gr.Markdown(html_center(i18n("训练角色选择（从训练数据中快速选择）"), "h3"))
+            with gr.Row():
+                model_name_dropdown = gr.Dropdown(
+                    label=i18n("模型名（训练实验名）"),
+                    choices=[],
+                    value="",
+                    interactive=True,
+                    scale=14,
+                )
+                refresh_models_btn = gr.Button(i18n("刷新模型列表"), variant="primary", scale=7)
+                auto_select_weights_btn = gr.Button(i18n("自动匹配权重"), variant="secondary", scale=7)
+            with gr.Row():
+                ref_sample_dropdown = gr.Dropdown(
+                    label=i18n("训练样本音频"),
+                    choices=[],
+                    value="",
+                    interactive=True,
+                    scale=14,
+                )
+                ref_sample_player = gr.Audio(
+                    label=i18n("样本预览"),
+                    type="filepath",
+                    scale=14,
+                )
+            apply_sample_btn = gr.Button(
+                i18n("应用选中样本到参考音频和文本"),
+                variant="primary",
+            )
         gr.Markdown(html_center(i18n("*请上传并填写参考信息"), "h3"))
         with gr.Row():
-            inp_ref = gr.Audio(label=i18n("请上传3~10秒内参考音频，超过会报错！"), type="filepath", scale=13)
+            inp_ref = gr.Audio(label=i18n("请上传参考音频（推荐3~10秒）"), type="filepath", scale=13)
             with gr.Column(scale=13):
                 ref_text_free = gr.Checkbox(
                     label=i18n("开启无参考文本模式。不填参考文本亦相当于开启。")
@@ -1406,6 +1569,36 @@ with gr.Blocks(title="GPT-SoVITS WebUI", analytics_enabled=False, js=js, css=css
             ],
         )
         GPT_dropdown.change(change_gpt_weights, [GPT_dropdown], [])
+
+        # ===== 新增事件绑定：训练角色选择 / 样本浏览 =====
+        refresh_models_btn.click(
+            fn=scan_model_names,
+            inputs=[],
+            outputs=[model_name_dropdown],
+        )
+        model_name_dropdown.change(
+            fn=on_model_name_change,
+            inputs=[model_name_dropdown],
+            outputs=[ref_sample_dropdown, ref_sample_player],
+        )
+        ref_sample_dropdown.change(
+            fn=on_ref_sample_change,
+            inputs=[ref_sample_dropdown, model_name_dropdown],
+            outputs=[ref_sample_player],
+        )
+        apply_sample_btn.click(
+            fn=on_apply_sample,
+            inputs=[ref_sample_dropdown, model_name_dropdown],
+            outputs=[inp_ref, prompt_text, ref_sample_dropdown],
+        )
+        auto_select_weights_btn.click(
+            fn=on_auto_select_weights,
+            inputs=[model_name_dropdown],
+            outputs=[GPT_dropdown, SoVITS_dropdown],
+        )
+        # 页面加载时自动扫描模型列表
+        app.load(fn=scan_model_names, inputs=[], outputs=[model_name_dropdown])
+
 
         # gr.Markdown(value=i18n("文本切分工具。太长的文本合成出来效果不一定好，所以太长建议先切。合成会根据文本的换行分开合成再拼起来。"))
         # with gr.Row():

--- a/GPT_SoVITS/inference_webui.py
+++ b/GPT_SoVITS/inference_webui.py
@@ -1245,6 +1245,34 @@ def _read_name2text_for_webui(logs_dir: Path) -> dict[str, dict[str, str]]:
     return output
 
 
+def _read_emotion_map_for_webui(model_name: str) -> dict[str, str]:
+    """读取 ASR 标注 .list 中的 emotion 列，返回 {audio_name|stem: emotion}。
+
+    扫描 output/asr_opt/<model_name>/ 下所有 *.list（4/5/6 列均兼容）。
+    无 emotion 列或文件不存在时返回空 dict。
+    """
+    from tools.list_metadata import parse_list_line
+
+    emotion_map: dict[str, str] = {}
+    list_dir = Path("output") / "asr_opt" / model_name
+    if not list_dir.exists():
+        return emotion_map
+    for list_path in sorted(list_dir.glob("*.list")):
+        try:
+            for line in list_path.read_text(encoding="utf-8", errors="ignore").splitlines():
+                item = parse_list_line(line)
+                if item is None or not item.emotion:
+                    continue
+                name = os.path.basename(item.wav_path.strip("\"'"))
+                if not name:
+                    continue
+                emotion_map[name] = item.emotion
+                emotion_map[Path(name).stem] = item.emotion
+        except Exception:
+            continue
+    return emotion_map
+
+
 def on_model_name_change(model_name: str):
     """模型名变化时，加载该模型的训练样本列表到下拉框与预览播放器。"""
     if not model_name:
@@ -1256,10 +1284,16 @@ def on_model_name_change(model_name: str):
     samples: list[tuple[str, str]] = []
     if wav_dir.exists():
         name2text = _read_name2text_for_webui(logs_dir)
+        emotion_map = _read_emotion_map_for_webui(model_name)
         for f in sorted(wav_dir.iterdir()):
             if f.is_file() and f.suffix.lower() in (".wav", ".mp3", ".flac"):
                 text = name2text.get(f.name, {}).get("text", "") or name2text.get(f.stem, {}).get("text", "")
-                label = f"{f.name}" + (f" | {text[:30]}" if text else "")
+                emotion = emotion_map.get(f.name, "") or emotion_map.get(f.stem, "")
+                label = f"{f.name}"
+                if text:
+                    label += f" | {text[:30]}"
+                if emotion:
+                    label += f" | 【{emotion}】"
                 samples.append((label, str(f)))
     choices = [s[0] for s in samples]
     value = samples[0][0] if samples else ""
@@ -1268,28 +1302,33 @@ def on_model_name_change(model_name: str):
 
 
 def on_ref_sample_change(sample_label: str, model_name: str):
-    """训练样本选择变化时，更新预览播放器。"""
+    """训练样本选择变化时，更新预览播放器与情绪/括注文本框。"""
     if not sample_label or not model_name:
-        return gr.Audio(value=None)
+        return gr.Audio(value=None), ""
     from config import exp_root
 
     wav_name = sample_label.split(" | ")[0]
     audio_path = Path(exp_root) / model_name / "5-wav32k" / wav_name
-    return gr.Audio(value=str(audio_path) if audio_path.exists() else None)
+    emotion_map = _read_emotion_map_for_webui(model_name)
+    emotion = emotion_map.get(wav_name, "") or emotion_map.get(Path(wav_name).stem, "")
+    return gr.Audio(value=str(audio_path) if audio_path.exists() else None), emotion
 
 
 def on_apply_sample(sample_label: str, model_name: str):
-    """应用选中样本：写入参考音频路径和参考文本。"""
+    """应用选中样本：写入参考音频路径、参考文本、情绪/括注。"""
     if not sample_label or not model_name:
-        return None, "", gr.Dropdown()
+        return None, "", gr.Dropdown(), ""
     from config import exp_root
 
     wav_name = sample_label.split(" | ")[0]
     audio_path = Path(exp_root) / model_name / "5-wav32k" / wav_name
     logs_dir = Path(exp_root) / model_name
     name2text = _read_name2text_for_webui(logs_dir)
+    emotion_map = _read_emotion_map_for_webui(model_name)
     text = name2text.get(wav_name, {}).get("text", "") or name2text.get(Path(wav_name).stem, {}).get("text", "")
-    return (str(audio_path) if audio_path.exists() else None), text, gr.Dropdown()
+    emotion = emotion_map.get(wav_name, "") or emotion_map.get(Path(wav_name).stem, "")
+    audio_out = str(audio_path) if audio_path.exists() else None
+    return audio_out, text, gr.Dropdown(), emotion
 
 
 def _scan_model_weights_for_webui() -> dict[str, dict[str, list[str]]]:
@@ -1412,6 +1451,12 @@ with gr.Blocks(title="GPT-SoVITS WebUI", analytics_enabled=False, js=js, css=css
                     )
                 )
                 prompt_text = gr.Textbox(label=i18n("参考音频的文本"), value="", lines=5, max_lines=5, scale=1)
+                ref_emotion_text = gr.Textbox(
+                    label=i18n("情绪/括注（来自训练样本，无数据留空）"),
+                    value="",
+                    interactive=False,
+                    scale=1,
+                )
             with gr.Column(scale=14):
                 prompt_language = gr.Dropdown(
                     label=i18n("参考音频的语种"),
@@ -1584,12 +1629,12 @@ with gr.Blocks(title="GPT-SoVITS WebUI", analytics_enabled=False, js=js, css=css
         ref_sample_dropdown.change(
             fn=on_ref_sample_change,
             inputs=[ref_sample_dropdown, model_name_dropdown],
-            outputs=[ref_sample_player],
+            outputs=[ref_sample_player, ref_emotion_text],
         )
         apply_sample_btn.click(
             fn=on_apply_sample,
             inputs=[ref_sample_dropdown, model_name_dropdown],
-            outputs=[inp_ref, prompt_text, ref_sample_dropdown],
+            outputs=[inp_ref, prompt_text, ref_sample_dropdown, ref_emotion_text],
         )
         auto_select_weights_btn.click(
             fn=on_auto_select_weights,

--- a/GPT_SoVITS/prepare_datasets/1-get-text.py
+++ b/GPT_SoVITS/prepare_datasets/1-get-text.py
@@ -20,6 +20,7 @@ import os.path
 from text.cleaner import clean_text
 from transformers import AutoModelForMaskedLM, AutoTokenizer
 from tools.my_utils import clean_path
+from tools.list_metadata import parse_list_line
 
 # inp_text=sys.argv[1]
 # inp_wav_dir=sys.argv[2]
@@ -126,7 +127,12 @@ if os.path.exists(txt_path) == False:
     }
     for line in lines[int(i_part) :: int(all_parts)]:
         try:
-            wav_name, spk_name, language, text = line.split("|")
+            # 兼容 4/5/6 列 .list：parse_list_line 只取训练所需前 4 列，
+            # 额外的 emotion/remark 列（proplus-hc-dev 分支）被静默忽略，不影响训练。
+            item = parse_list_line(line)
+            if item is None:
+                raise ValueError("list 行列数不足，需至少 4 列：wav_path|speaker_name|language|text")
+            wav_name, language, text = item.wav_path, item.language, item.text
             # todo.append([name,text,"zh"])
             if language in language_v1_to_language_v2.keys():
                 todo.append([wav_name, text, language_v1_to_language_v2.get(language, language)])

--- a/api_v2.py
+++ b/api_v2.py
@@ -637,6 +637,36 @@ def _read_name2text(logs_dir: Path) -> dict[str, dict[str, str]]:
     return output
 
 
+def _read_emotion_map(model_name: str) -> dict[str, str]:
+    """读取 ASR 标注 .list 中的 emotion 列，返回 {audio_name|stem: emotion}。
+
+    扫描 output/asr_opt/<model_name>/ 下所有 *.list（兼容 4/5/6 列）。
+    兼容 proplus-hc-dev 分支训练数据：emotion 为第 5 列，缺省为空串。
+    无 .list 或无 emotion 列时返回空 dict。
+    """
+    from tools.list_metadata import parse_list_line
+
+    emotion_map: dict[str, str] = {}
+    list_dir = Path("output") / "asr_opt" / model_name
+    if not list_dir.exists():
+        return emotion_map
+    for list_path in sorted(list_dir.glob("*.list")):
+        try:
+            for line in list_path.read_text(encoding="utf-8", errors="ignore").splitlines():
+                item = parse_list_line(line)
+                if item is None or not item.emotion:
+                    continue
+                name = os.path.basename(item.wav_path.strip("\"'"))
+                if not name:
+                    continue
+                emotion_map[name] = item.emotion
+                emotion_map[Path(name).stem] = item.emotion
+        except Exception:
+            continue
+    return emotion_map
+
+
+
 def _safe_logs_subpath(model_name: str, *parts: str) -> Path | None:
     """解析 logs/<model_name>/<parts...> 路径并做目录穿越校验。
 
@@ -706,6 +736,7 @@ async def list_model_samples(model_name: str):
     if logs_abs is None or not logs_abs.exists():
         return JSONResponse(status_code=404, content={"message": f"model '{model_name}' not found"})
     name2text = _read_name2text(logs_abs)
+    emotion_map = _read_emotion_map(model_name)
     wav_dir = logs_abs / "5-wav32k"
     samples: list[dict] = []
     if wav_dir.exists():
@@ -718,11 +749,13 @@ async def list_model_samples(model_name: str):
             if entry is None:
                 continue  # 与 name2text 取交集，只返回有标注的样本
             rel = os.path.relpath(f, now_dir)
+            emotion = emotion_map.get(f.name, "") or emotion_map.get(f.stem, "")
             samples.append({
                 "audio_name": f.name,
                 "audio_path": rel.replace(os.sep, "/"),
                 "text": entry["text"],
                 "lang": entry["lang"],
+                "emotion": emotion,
             })
     return {"model_name": model_name, "samples": samples, "total": len(samples)}
 

--- a/api_v2.py
+++ b/api_v2.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 # WebAPI文档
 
@@ -102,8 +104,10 @@ RESP:
 """
 
 import os
+import re
 import sys
 import traceback
+from pathlib import Path
 from typing import Generator, Union
 
 now_dir = os.getcwd()
@@ -112,11 +116,12 @@ sys.path.append("%s/GPT_SoVITS" % (now_dir))
 
 import argparse
 import subprocess
+import uuid
 import wave
 import signal
 import numpy as np
 import soundfile as sf
-from fastapi import FastAPI, Response
+from fastapi import FastAPI, Response, UploadFile, File
 from fastapi.responses import StreamingResponse, JSONResponse
 import uvicorn
 from io import BytesIO
@@ -124,6 +129,7 @@ from tools.i18n.i18n import I18nAuto
 from GPT_SoVITS.TTS_infer_pack.TTS import TTS, TTS_Config
 from GPT_SoVITS.TTS_infer_pack.text_segmentation_method import get_method_names as get_cut_method_names
 from pydantic import BaseModel
+from config import GPT_weight_root, SoVITS_weight_root, exp_root
 import threading
 
 # print(sys.path)
@@ -563,6 +569,193 @@ async def set_sovits_weights(weights_path: str = None):
     except Exception as e:
         return JSONResponse(status_code=400, content={"message": "change sovits weight failed", "Exception": str(e)})
     return JSONResponse(status_code=200, content={"message": "success"})
+
+
+# ===================== 训练角色 / 训练样本 / 状态 辅助函数 =====================
+def _extract_exp_name_from_gpt_weight(filename: str) -> str:
+    """从 GPT 权重文件名提取 exp_name。
+    例: '光头TTS-华-e10.ckpt' -> '光头TTS-华'
+    """
+    stem = Path(filename).stem
+    return re.split(r"-e\d+", stem, flags=re.IGNORECASE)[0]
+
+
+def _extract_exp_name_from_sovits_weight(filename: str) -> str:
+    """从 SoVITS 权重文件名提取 exp_name。
+    例: '光头TTS-华_e4_s72.pth' -> '光头TTS-华'
+    """
+    stem = Path(filename).stem
+    return re.split(r"_e\d+_s\d+", stem, flags=re.IGNORECASE)[0]
+
+
+def _scan_model_weights() -> dict[str, dict[str, list[str]]]:
+    """扫描所有权重目录，按 exp_name 分组。
+    返回: {"光头TTS-华": {"gpt": [...], "sovits": [...]}}
+    """
+    grouped: dict[str, dict[str, list[str]]] = {}
+    for root in GPT_weight_root:
+        root_path = Path(root)
+        if not root_path.exists():
+            continue
+        for f in root_path.iterdir():
+            if f.is_file() and f.suffix == ".ckpt":
+                name = _extract_exp_name_from_gpt_weight(f.name)
+                grouped.setdefault(name, {"gpt": [], "sovits": []})
+                grouped[name]["gpt"].append(f"{root}/{f.name}")
+    for root in SoVITS_weight_root:
+        root_path = Path(root)
+        if not root_path.exists():
+            continue
+        for f in root_path.iterdir():
+            if f.is_file() and f.suffix == ".pth":
+                name = _extract_exp_name_from_sovits_weight(f.name)
+                grouped.setdefault(name, {"gpt": [], "sovits": []})
+                grouped[name]["sovits"].append(f"{root}/{f.name}")
+    return grouped
+
+
+def _read_name2text(logs_dir: Path) -> dict[str, dict[str, str]]:
+    """读取 2-name2text.txt，返回 {wav_name: {"text": ..., "lang": ...}}。
+
+    每行 Tab 分隔 4 字段: wav_name\tphones\tword2ph\tnorm_text。
+    同时以 wav_name 和其 stem（去扩展名）建立索引，便于按文件名或 stem 查询。
+    """
+    path = logs_dir / "2-name2text.txt"
+    if not path.exists():
+        return {}
+    output: dict[str, dict[str, str]] = {}
+    for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+        parts = line.split("\t")
+        if len(parts) < 4:
+            continue
+        wav_name = parts[0].strip()
+        text = parts[3].strip()
+        if wav_name and text:
+            entry = {"text": text, "lang": "zh"}
+            output[wav_name] = entry
+            output[Path(wav_name).stem] = entry
+    return output
+
+
+def _safe_logs_subpath(model_name: str, *parts: str) -> Path | None:
+    """解析 logs/<model_name>/<parts...> 路径并做目录穿越校验。
+
+    若解析后的绝对路径不在 exp_root 之内，返回 None（拒绝），否则返回绝对路径。
+    """
+    root_abs = Path(exp_root).resolve()
+    target = (root_abs / model_name, *parts)
+    target_abs = Path(*[str(p) for p in target]).resolve()
+    try:
+        target_abs.relative_to(root_abs)
+    except ValueError:
+        return None
+    return target_abs
+
+
+@APP.get("/models")
+async def list_models():
+    """列出所有训练角色（logs 目录名）及其匹配的权重。
+
+    从 logs/ 目录扫描子目录名作为模型名，再从 GPT/SoVITS 权重目录中
+    匹配同名权重文件。支持 GPT_weights、GPT_weights_v2 等 6 个版本目录。
+    """
+    weights = _scan_model_weights()
+    logs_root = Path(exp_root)
+    models: list[dict] = []
+    if logs_root.exists():
+        for d in logs_root.iterdir():
+            if not d.is_dir():
+                continue
+            name = d.name
+            name2text = _read_name2text(d)
+            has_training_data = (d / "2-name2text.txt").exists()
+            # name2text 同时以 wav_name 和 stem 建索引（2 个键），样本数按 wav_name 计：即原始行数
+            sample_count = len(name2text) // 2 if name2text else 0
+            w = weights.get(name, {"gpt": [], "sovits": []})
+            models.append({
+                "name": name,
+                "gpt_weights": sorted(w["gpt"]),
+                "sovits_weights": sorted(w["sovits"]),
+                "has_training_data": has_training_data,
+                "sample_count": sample_count,
+            })
+    # 补上 logs 中没有但有权重的模型
+    existing_names = {m["name"] for m in models}
+    for name, w in weights.items():
+        if name in existing_names:
+            continue
+        models.append({
+            "name": name,
+            "gpt_weights": sorted(w["gpt"]),
+            "sovits_weights": sorted(w["sovits"]),
+            "has_training_data": (Path(exp_root) / name).exists(),
+            "sample_count": 0,
+        })
+    models.sort(key=lambda m: m["name"])
+    return {"models": models}
+
+
+@APP.get("/models/{model_name}/samples")
+async def list_model_samples(model_name: str):
+    """列出指定角色的训练样本（音频文件 + 参考文本）。
+
+    读取 logs/<model_name>/2-name2text.txt 解析标注，
+    扫描 logs/<model_name>/5-wav32k/ 获取音频文件列表。
+    """
+    logs_abs = _safe_logs_subpath(model_name)
+    if logs_abs is None or not logs_abs.exists():
+        return JSONResponse(status_code=404, content={"message": f"model '{model_name}' not found"})
+    name2text = _read_name2text(logs_abs)
+    wav_dir = logs_abs / "5-wav32k"
+    samples: list[dict] = []
+    if wav_dir.exists():
+        for f in sorted(wav_dir.iterdir()):
+            if not f.is_file():
+                continue
+            if f.suffix.lower() not in (".wav", ".mp3", ".flac"):
+                continue
+            entry = name2text.get(f.name) or name2text.get(f.stem)
+            if entry is None:
+                continue  # 与 name2text 取交集，只返回有标注的样本
+            rel = os.path.relpath(f, now_dir)
+            samples.append({
+                "audio_name": f.name,
+                "audio_path": rel.replace(os.sep, "/"),
+                "text": entry["text"],
+                "lang": entry["lang"],
+            })
+    return {"model_name": model_name, "samples": samples, "total": len(samples)}
+
+
+@APP.get("/status")
+async def service_status():
+    """返回当前服务状态：加载的权重、版本、设备。"""
+    return {
+        "version": tts_config.version,
+        "device": str(tts_config.device),
+        "gpt_weights": tts_config.t2s_weights_path,
+        "sovits_weights": tts_config.vits_weights_path,
+        "languages": list(tts_config.languages),
+    }
+
+
+@APP.post("/upload_ref")
+async def upload_reference_audio(file: UploadFile = File(...)):
+    """上传参考音频文件，返回服务端本地路径供 /tts 使用。
+
+    同机部署不需要此端点（直接传本地路径即可）。
+    """
+    upload_dir = Path("uploaded_audio")
+    upload_dir.mkdir(parents=True, exist_ok=True)
+    raw_name = os.path.basename(file.filename or "")
+    # 文件名白名单清洗：仅保留字母数字、中文、._- 与扩展名前的点
+    safe_name = re.sub(r"[^\w.\u4e00-\u9fff\-]", "_", raw_name) or "ref.wav"
+    save_name = f"{uuid.uuid4().hex[:16]}_{safe_name}"
+    save_path = upload_dir / save_name
+    content = await file.read()
+    save_path.write_bytes(content)
+    rel = os.path.relpath(save_path, now_dir)
+    return {"path": rel.replace(os.sep, "/")}
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,6 @@ pydantic<=2.10.6
 ctranslate2>=4.0,<5
 av>=11
 tqdm
+
+# FastAPI file upload support for /upload_ref endpoint
+python-multipart

--- a/tools/list_metadata.py
+++ b/tools/list_metadata.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ListLine:
+    """一条 `.list` 标注行（兼容 4/5/6 列）。
+
+    列定义: wav_path|speaker_name|language|text[|emotion|remark]
+    训练只用前 4 列（training_fields）；emotion / remark 为元数据，
+    不参与模型训练，用于标注与参考音频展示。
+    """
+
+    wav_path: str
+    speaker_name: str
+    language: str
+    text: str
+    emotion: str = ""
+    remark: str = ""
+
+    @property
+    def training_fields(self):
+        return [self.wav_path, self.speaker_name, self.language, self.text]
+
+
+def _clean(value):
+    return str(value or "").strip()
+
+
+def parse_list_line(line):
+    """解析一行 `.list`。列数 < 4 返回 None；emotion/remark 缺省为空串。"""
+    parts = str(line or "").rstrip("\r\n").split("|")
+    if len(parts) < 4:
+        return None
+    return ListLine(
+        wav_path=_clean(parts[0]),
+        speaker_name=_clean(parts[1]),
+        language=_clean(parts[2]),
+        text=_clean(parts[3]),
+        emotion=_clean(parts[4]) if len(parts) >= 5 else "",
+        remark=_clean(parts[5]) if len(parts) >= 6 else "",
+    )
+
+
+def format_list_line(item):
+    """把 ListLine 格式化为 6 列 `.list` 行（emotion/remark 为空也保留分隔符）。
+
+    注意：写出 6 列以保证与 proplus-hc-dev 分支互操作，主分支训练侧
+    （1-get-text.py）已用 parse_list_line 只消费前 4 列，多余列不影响训练。
+    """
+    return "|".join(
+        [
+            str(item.wav_path or ""),
+            str(item.speaker_name or ""),
+            str(item.language or ""),
+            str(item.text or ""),
+            str(item.emotion or ""),
+            str(item.remark or ""),
+        ]
+    )

--- a/tools/subfix_webui.py
+++ b/tools/subfix_webui.py
@@ -32,6 +32,7 @@ g_batch = 10
 g_text_list = []
 g_audio_list = []
 g_checkbox_list = []
+g_emotion_list = []
 g_data_json = []
 
 
@@ -43,7 +44,13 @@ def reload_data(index, batch):
     datas = g_data_json[index : index + batch]
     output = []
     for d in datas:
-        output.append({g_json_key_text: d[g_json_key_text], g_json_key_path: d[g_json_key_path]})
+        output.append(
+            {
+                g_json_key_text: d[g_json_key_text],
+                g_json_key_path: d[g_json_key_path],
+                "emotion": d.get("emotion", ""),
+            }
+        )
     return output
 
 
@@ -52,26 +59,26 @@ def b_change_index(index, batch):
     g_index, g_batch = index, batch
     datas = reload_data(index, batch)
     output = []
+    # 文本框组
     for i, _ in enumerate(datas):
         output.append(
-            # gr.Textbox(
-            #     label=f"Text {i+index}",
-            #     value=_[g_json_key_text]#text
-            # )
             {"__type__": "update", "label": f"Text {i + index}", "value": _[g_json_key_text]}
         )
     for _ in range(g_batch - len(datas)):
+        output.append({"__type__": "update", "label": "Text", "value": ""})
+    # 情绪/括注框组（与文本框一一对应）
+    for i, _ in enumerate(datas):
         output.append(
-            # gr.Textbox(
-            #     label=f"Text",
-            #     value=""
-            # )
-            {"__type__": "update", "label": "Text", "value": ""}
+            {"__type__": "update", "label": f"情绪/括注 {i + index}", "value": _.get("emotion", "")}
         )
+    for _ in range(g_batch - len(datas)):
+        output.append({"__type__": "update", "label": "情绪/括注", "value": ""})
+    # 音频组
     for _ in datas:
         output.append(_[g_json_key_path])
     for _ in range(g_batch - len(datas)):
         output.append(None)
+    # 复选框组
     for _ in range(g_batch):
         output.append(False)
     return output
@@ -93,14 +100,24 @@ def b_previous_index(index, batch):
         return 0, *b_change_index(0, batch)
 
 
-def b_submit_change(*text_list):
+def b_submit_change(*args):
+    # 输入约定：[text×batch] + [emotion×batch]（由事件绑定顺序拼成）
     global g_data_json
+    half = g_batch
+    text_list = args[:half]
+    emotion_list = args[half:]
     change = False
     for i, new_text in enumerate(text_list):
         if g_index + i <= g_max_json_index:
             new_text = new_text.strip() + " "
             if g_data_json[g_index + i][g_json_key_text] != new_text:
                 g_data_json[g_index + i][g_json_key_text] = new_text
+                change = True
+    for i, new_emotion in enumerate(emotion_list):
+        if g_index + i <= g_max_json_index:
+            new_emotion = (new_emotion or "").strip()
+            if g_data_json[g_index + i].get("emotion", "") != new_emotion:
+                g_data_json[g_index + i]["emotion"] = new_emotion
                 change = True
     if change:
         b_save_file()
@@ -226,13 +243,25 @@ def b_save_json():
 
 
 def b_save_list():
+    from tools.list_metadata import format_list_line, ListLine
+
     with open(g_load_file, "w", encoding="utf-8") as file:
         for data in g_data_json:
-            wav_path = data["wav_path"]
-            speaker_name = data["speaker_name"]
-            language = data["language"]
-            text = data["text"]
-            file.write(f"{wav_path}|{speaker_name}|{language}|{text}".strip() + "\n")
+            # 写出 6 列以保留 emotion/remark（proplus-hc-dev 互操作）；
+            # 主分支训练侧（1-get-text.py）只消费前 4 列，多余列不影响训练。
+            file.write(
+                format_list_line(
+                    ListLine(
+                        wav_path=data.get("wav_path", ""),
+                        speaker_name=data.get("speaker_name", ""),
+                        language=data.get("language", ""),
+                        text=data.get("text", ""),
+                        emotion=data.get("emotion", ""),
+                        remark=data.get("remark", ""),
+                    )
+                ).strip()
+                + "\n"
+            )
 
 
 def b_load_json():
@@ -245,17 +274,25 @@ def b_load_json():
 
 def b_load_list():
     global g_data_json, g_max_json_index
+    from tools.list_metadata import parse_list_line
+
     with open(g_load_file, "r", encoding="utf-8") as source:
         data_list = source.readlines()
         for _ in data_list:
-            data = _.split("|")
-            if len(data) == 4:
-                wav_path, speaker_name, language, text = data
-                g_data_json.append(
-                    {"wav_path": wav_path, "speaker_name": speaker_name, "language": language, "text": text.strip()}
-                )
-            else:
-                print("error line:", data)
+            item = parse_list_line(_)
+            if item is None:
+                print("error line:", _)
+                continue
+            g_data_json.append(
+                {
+                    "wav_path": item.wav_path,
+                    "speaker_name": item.speaker_name,
+                    "language": item.language,
+                    "text": item.text,
+                    "emotion": item.emotion,
+                    "remark": item.remark,
+                }
+            )
         g_max_json_index = len(g_data_json) - 1
 
 
@@ -338,9 +375,16 @@ if __name__ == "__main__":
                         text = gr.Textbox(label="Text", visible=True, scale=5)
                         audio_output = gr.Audio(label="Output Audio", visible=True, scale=5)
                         audio_check = gr.Checkbox(label="Yes", show_label=True, info="Choose Audio", scale=1)
+                        emotion = gr.Textbox(
+                            label="情绪/括注",
+                            visible=True,
+                            scale=3,
+                            placeholder="可选：台词对应的表演情绪或括注",
+                        )
                         g_text_list.append(text)
                         g_audio_list.append(audio_output)
                         g_checkbox_list.append(audio_check)
+                        g_emotion_list.append(emotion)
 
         with gr.Row():
             batchsize_slider = gr.Slider(
@@ -356,15 +400,16 @@ if __name__ == "__main__":
                 index_slider,
                 batchsize_slider,
             ],
-            outputs=[*g_text_list, *g_audio_list, *g_checkbox_list],
+            outputs=[*g_text_list, *g_emotion_list, *g_audio_list, *g_checkbox_list],
         )
 
         btn_submit_change.click(
             b_submit_change,
             inputs=[
                 *g_text_list,
+                *g_emotion_list,
             ],
-            outputs=[index_slider, *g_text_list, *g_audio_list, *g_checkbox_list],
+            outputs=[index_slider, *g_text_list, *g_emotion_list, *g_audio_list, *g_checkbox_list],
         )
 
         btn_previous_index.click(
@@ -373,7 +418,7 @@ if __name__ == "__main__":
                 index_slider,
                 batchsize_slider,
             ],
-            outputs=[index_slider, *g_text_list, *g_audio_list, *g_checkbox_list],
+            outputs=[index_slider, *g_text_list, *g_emotion_list, *g_audio_list, *g_checkbox_list],
         )
 
         btn_next_index.click(
@@ -382,25 +427,25 @@ if __name__ == "__main__":
                 index_slider,
                 batchsize_slider,
             ],
-            outputs=[index_slider, *g_text_list, *g_audio_list, *g_checkbox_list],
+            outputs=[index_slider, *g_text_list, *g_emotion_list, *g_audio_list, *g_checkbox_list],
         )
 
         btn_delete_audio.click(
             b_delete_audio,
             inputs=[*g_checkbox_list],
-            outputs=[index_slider, *g_text_list, *g_audio_list, *g_checkbox_list],
+            outputs=[index_slider, *g_text_list, *g_emotion_list, *g_audio_list, *g_checkbox_list],
         )
 
         btn_merge_audio.click(
             b_merge_audio,
             inputs=[interval_slider, *g_checkbox_list],
-            outputs=[index_slider, *g_text_list, *g_audio_list, *g_checkbox_list],
+            outputs=[index_slider, *g_text_list, *g_emotion_list, *g_audio_list, *g_checkbox_list],
         )
 
         btn_audio_split.click(
             b_audio_split,
             inputs=[splitpoint_slider, *g_checkbox_list],
-            outputs=[index_slider, *g_text_list, *g_audio_list, *g_checkbox_list],
+            outputs=[index_slider, *g_text_list, *g_emotion_list, *g_audio_list, *g_checkbox_list],
         )
 
         btn_invert_selection.click(b_invert_selection, inputs=[*g_checkbox_list], outputs=[*g_checkbox_list])
@@ -413,7 +458,7 @@ if __name__ == "__main__":
                 index_slider,
                 batchsize_slider,
             ],
-            outputs=[*g_text_list, *g_audio_list, *g_checkbox_list],
+            outputs=[*g_text_list, *g_emotion_list, *g_audio_list, *g_checkbox_list],
         )
 
     demo.launch(


### PR DESCRIPTION
## Overview

This PR adds three independent, backward-compatible capabilities to GPT-SoVITS. Each can be reviewed/merged on its own merits; they happen to share a feature branch.

1. **REST API for browsing trained models & samples** (api_v2.py, port 9880) — lets external orchestrators discover training data (reference audio + text) programmatically, removing the need to manually copy paths/text.
2. **Relax the hardcoded 3–10s reference-audio duration gate** — converts a hard `raise OSError` (which blocks legitimate synthesis) into a soft warning, so out-of-range refs still synthesize with a quality advisory.
3. **Emotion / remark annotation field + compatibility with 6-column `.list`** — adds an `emotion` annotation column end-to-end (not used for training) and makes the training/annotation pipeline accept `.list` files with extra metadata columns.

All changes are **additive / non-breaking**: existing endpoint signatures, training pipeline logic, and `.list` round-trips are unchanged. New code uses `from __future__ import annotations` for py3.10 compatibility.

---

## 1. Training data browsing API (`api_v2.py`)

Four new endpoints (existing `/tts`, `/set_gpt_weights`, `/set_sovits_weights` untouched):

| Method | Path | Purpose |
|---|---|---|
| GET | `/models` | List trained characters (exp_name from `logs/`) with matched GPT/SoVITS weights + sample count |
| GET | `/models/{name}/samples` | List training samples (audio path + reference text), with path-traversal guard |
| GET | `/status` | Currently loaded weights / version / device |
| POST | `/upload_ref` | Upload a reference audio (for remote deployments) |

Helper design notes:
- exp_name is extracted from weight filenames via regex (e.g. `光头TTS-华-e10.ckpt` → `光头TTS-华`).
- `/models/{name}/samples` validates that the resolved path stays inside `exp_root` (defense against directory traversal).
- `audio_path` is returned relative to the repo root (and `\` → `/` on Windows).

---

## 2. Relax reference-audio duration gate (soft warning instead of hard error)

The 3–10s check currently `raise OSError`s and aborts synthesis. In practice many valid refs fall outside this range and still synthesize fine — the gate is too strict and blocks legitimate jobs. Changed to a soft warning:

- `TTS_infer_pack/TTS.py` (`_set_prompt_semantic`): `raise OSError` → `print("[Warning] ...")`
- `inference_webui.py`: `raise OSError` → `gr.Warning("... may affect quality")` (advisory wording)
- Inference WebUI label changed from "超过会报错！" to "推荐3~10秒".

The TTS inference pipeline body logic is **not** modified — only the gate behavior.

---

## 3. Emotion annotation field + 6-column `.list` compatibility

### Why
Annotations sometimes carry per-line metadata (emotion / remark) useful for scripting and reference selection, but they must not pollute training. Some forks/trainers already emit **6-column** `.list` files (`wav_path|speaker|lang|text|emotion|remark`). On `main`, these crash or get silently dropped at three hardcoded spots:

| Location | Before (main) | After |
|---|---|---|
| `prepare_datasets/1-get-text.py:129` | `a,b,c,d = line.split("|")` — **strict 4-col unpack, ValueError on 6 cols → training crashes** | `parse_list_line(line)` (consumes only first 4 cols; extra cols ignored) |
| `subfix_webui.b_load_list` | `if len(data)==4` — 6-col lines discarded as "error line" | `parse_list_line` (accepts ≥4 cols, preserves emotion/remark) |
| `subfix_webui.b_save_list` | writes exactly 4 cols — **emotion/remark lost on save** | writes 6 cols (round-trip safe; training still reads only 4) |

### New shared parser: `tools/list_metadata.py`
A small, dependency-free dataclass parser (`parse_list_line` / `format_list_line`) reused by the training preprocessor and the annotation UI. `training_fields` always yields exactly 4 columns, so the training pipeline never sees emotion/remark.

### Annotation UI (`subfix_webui.py`)
- Each audio row gets a new **「情绪/括注」** textbox; the 8 paging events are wired to read/write it.
- Load/save round-trips preserve emotion across 4/5/6-column inputs.

### Inference WebUI & API
- Selecting a training sample shows its emotion (read from `output/asr_opt/<exp>/*.list`); if a model has no emotion data, the field is empty (graceful absence).
- `GET /models/{name}/samples` now includes an `emotion` field.

`emotion` / `remark` are **metadata only** — they never enter the model.

---

## Backward compatibility

- Native 4-column `.list` (the `main` default) trains and round-trips unchanged.
- Existing API endpoints: signatures and response shapes unchanged.
- TTS inference pipeline: only the duration gate's *behavior* changed (raise → warn); core logic untouched.
- New endpoints/files are purely additive.

---

## Testing

- `python -m py_compile` passes on all 7 modified/new files.
- `list_metadata` parser unit checks: 4/5/6-col parsing, `training_fields` is always 4 cols, `format` always emits 6 cols, round-trip preserves emotion — all pass.
- A pre-existing `SyntaxWarning` (`\d` escape in `config.py:custom_sort_key`) is unrelated to this PR.

Manual verification (start service, exercise endpoints, pick a 2s/15s ref) recommended on the reviewer's environment.

---

## Files changed

- `api_v2.py` — 4 new endpoints + helpers
- `GPT_SoVITS/inference_webui.py` — training-character/sample browsing UI, duration soft-warn, emotion display
- `GPT_SoVITS/TTS_infer_pack/TTS.py` — duration soft-warn
- `GPT_SoVITS/prepare_datasets/1-get-text.py` — 6-col `.list` compatibility (core fix)
- `tools/subfix_webui.py` — emotion textbox + 6-col load/save
- `tools/list_metadata.py` — **new** shared `.list` parser
- `requirements.txt` — `python-multipart` (for `/upload_ref`)

Happy to split into separate PRs if maintainers prefer (each of the 3 areas is self-contained).