### PR TITLE
Fix : Bump Windows dependencies and single-GPU S2 training 

### DIFF
--- a/GPT_SoVITS/s2_train.py
+++ b/GPT_SoVITS/s2_train.py
@@ -55,6 +55,10 @@ def main():
         n_gpus = torch.cuda.device_count()
     else:
         n_gpus = 1
+    if n_gpus <= 1:
+        run(0, n_gpus, hps)
+        return
+
     os.environ["MASTER_ADDR"] = "localhost"
     os.environ["MASTER_PORT"] = str(randint(20000, 55555))
 
@@ -69,6 +73,22 @@ def main():
 
 
 def run(rank, n_gpus, hps):
+    use_ddp = n_gpus > 1
+    if use_ddp:
+        dist.init_process_group(
+            backend="gloo" if os.name == "nt" or not torch.cuda.is_available() else "nccl",
+            init_method="env://?use_libuv=False",
+            world_size=n_gpus,
+            rank=rank,
+        )
+    try:
+        _run(rank, n_gpus, hps, use_ddp)
+    finally:
+        if use_ddp and dist.is_initialized():
+            dist.destroy_process_group()
+
+
+def _run(rank, n_gpus, hps, use_ddp):
     global global_step
     if rank == 0:
         logger = utils.get_logger(hps.data.exp_dir)
@@ -76,13 +96,6 @@ def run(rank, n_gpus, hps):
         # utils.check_git_hash(hps.s2_ckpt_dir)
         writer = SummaryWriter(log_dir=hps.s2_ckpt_dir)
         writer_eval = SummaryWriter(log_dir=os.path.join(hps.s2_ckpt_dir, "eval"))
-
-    dist.init_process_group(
-        backend="gloo" if os.name == "nt" or not torch.cuda.is_available() else "nccl",
-        init_method="env://?use_libuv=False",
-        world_size=n_gpus,
-        rank=rank,
-    )
     torch.manual_seed(hps.train.seed)
     if torch.cuda.is_available():
         torch.cuda.set_device(rank)
@@ -196,10 +209,10 @@ def run(rank, n_gpus, hps):
         betas=hps.train.betas,
         eps=hps.train.eps,
     )
-    if torch.cuda.is_available():
+    if torch.cuda.is_available() and use_ddp:
         net_g = DDP(net_g, device_ids=[rank], find_unused_parameters=True)
         net_d = DDP(net_d, device_ids=[rank], find_unused_parameters=True)
-    else:
+    elif not torch.cuda.is_available():
         net_g = net_g.to(device)
         net_d = net_d.to(device)
 
@@ -238,7 +251,7 @@ def run(rank, n_gpus, hps):
                     torch.load(hps.train.pretrained_s2G, map_location="cpu", weights_only=False)["weight"],
                     strict=False,
                 )
-                if torch.cuda.is_available()
+                if hasattr(net_g, "module")
                 else net_g.load_state_dict(
                     torch.load(hps.train.pretrained_s2G, map_location="cpu", weights_only=False)["weight"],
                     strict=False,
@@ -256,7 +269,7 @@ def run(rank, n_gpus, hps):
                 net_d.module.load_state_dict(
                     torch.load(hps.train.pretrained_s2D, map_location="cpu", weights_only=False)["weight"], strict=False
                 )
-                if torch.cuda.is_available()
+                if hasattr(net_d, "module")
                 else net_d.load_state_dict(
                     torch.load(hps.train.pretrained_s2D, map_location="cpu", weights_only=False)["weight"],
                 ),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,10 @@
---no-binary=opencc
 numpy<2.0
 scipy
 tensorboard
 librosa==0.10.2
 numba
 pytorch-lightning>=2.4
-gradio<5
+gradio==4.44.1
 ffmpeg-python
 onnxruntime; platform_machine == "aarch64" or platform_machine == "arm64"
 onnxruntime-gpu; platform_machine == "x86_64" or platform_machine == "AMD64"
@@ -34,7 +33,8 @@ g2pk2
 ko_pron
 opencc
 python_mecab_ko; sys_platform != 'win32'
-fastapi[standard]>=0.115.2
+fastapi[standard]==0.124.0
+starlette==0.49.3
 x_transformers
 torchmetrics<=1.5
 pydantic<=2.10.6


### PR DESCRIPTION
## Summary

- Allow pip to install the prebuilt OpenCC wheel on Windows instead of forcing a local source build.
- Pin a compatible Gradio / FastAPI / Starlette combination.
- Run S2 training directly on CPU and single-GPU systems.
- Initialize multiprocessing, distributed training, and DDP only when multiple GPUs are available.
- Ensure the distributed process group is cleaned up if multi-GPU training exits with an exception.
- Support loading pretrained weights into both DDP-wrapped and unwrapped models.

## Background

### OpenCC installation on Windows

`requirements.txt` previously included:

```text
--no-binary=opencc
```
This prevented pip from using the available Windows wheel and forced OpenCC to compile locally. On systems without a suitable native build environment, installation failed with:

> `Failed to build opencc`

Removing this option allows pip to install the existing Windows wheel.

## WebUI dependency bump

The previous constraints allowed fresh installations to resolve incompatible Gradio, FastAPI, and Starlette versions.
This PR pins the tested combination:

```text
gradio==4.44.1
fastapi[standard]==0.124.0
starlette==0.49.3
```

Starlette 0.49.3 remains compatible with Gradio 4.44.1's legacy TemplateResponse call style and includes the security fix released in Starlette 0.49.1 for **GHSA-7f5h-v6xp-fcq8 / CVE-2025-62727.**

Related: #2806 #2762 

## Single-GPU S2 training on Windows

S2 training previously used mp.spawn, a Gloo process group, and DistributedDataParallel even when only one GPU was available.
On Windows this can cause the training subprocess to terminate during the first step with:
```text
process 0 terminated with exit code 3221225477

```

This PR keeps the distributed path for multi-GPU training while running CPU and single-GPU training directly.
Addresses #2806 

##Validation



- Confirmed the OpenCC CPython 3.10 Windows wheel resolves successfully.
- Confirmed the pinned Gradio / FastAPI / Starlette dependency combination passes pip check.
- Confirmed a minimal Gradio application returns HTTP 200 through TestClient.
- Confirmed the project WebUI starts successfully on its configured local port.
- Verified single-GPU launch does not call mp.spawn, initialize torch.distributed, or wrap either model in DDP.
- Verified multi-GPU exceptions still clean up the initialized process group.

