### PR TITLE
refactor(i18n): extract shared language resolution helper

### DIFF
--- a/GPT_SoVITS/inference_webui.py
+++ b/GPT_SoVITS/inference_webui.py
@@ -124,10 +124,9 @@ from text import cleaned_text_to_sequence
 from text.cleaner import clean_text
 
 from tools.assets import css, js, top_html
-from tools.i18n.i18n import I18nAuto, scan_language_list
+from tools.i18n.i18n import I18nAuto, resolve_language
 
-language = os.environ.get("language", "Auto")
-language = sys.argv[-1] if sys.argv[-1] in scan_language_list() else language
+language = resolve_language(os.environ.get("language", "Auto"))
 i18n = I18nAuto(language=language)
 
 # os.environ['PYTORCH_ENABLE_MPS_FALLBACK'] = '1'  # 确保直接启动推理UI时也能够设置。

--- a/tests/test_i18n_language.py
+++ b/tests/test_i18n_language.py
@@ -1,0 +1,13 @@
+from tools.i18n.i18n import resolve_language
+
+
+def test_resolve_language_prefers_supported_last_cli_locale():
+    assert resolve_language("fr_FR", ["webui.py", "zh_CN"]) == "zh_CN"
+
+
+def test_resolve_language_keeps_language_for_unknown_last_argument():
+    assert resolve_language("fr_FR", ["webui.py", "--port", "9872"]) == "fr_FR"
+
+
+def test_resolve_language_keeps_language_for_empty_argv():
+    assert resolve_language("fr_FR", []) == "fr_FR"

--- a/tools/i18n/i18n.py
+++ b/tools/i18n/i18n.py
@@ -1,6 +1,7 @@
 import json
 import locale
 import os
+import sys
 
 I18N_JSON_DIR: os.PathLike = os.path.join(os.path.dirname(os.path.relpath(__file__)), "locale")
 
@@ -17,6 +18,14 @@ def scan_language_list():
         if name.endswith(".json"):
             language_list.append(name.split(".")[0])
     return language_list
+
+
+def resolve_language(language="Auto", argv=None):
+    if argv is None:
+        argv = sys.argv
+    if argv and argv[-1] in scan_language_list():
+        return argv[-1]
+    return language
 
 
 class I18nAuto:

--- a/webui.py
+++ b/webui.py
@@ -61,9 +61,9 @@ import subprocess
 from subprocess import Popen
 
 from tools.assets import css, js, top_html
-from tools.i18n.i18n import I18nAuto, scan_language_list
+from tools.i18n.i18n import I18nAuto, resolve_language
 
-language = sys.argv[-1] if sys.argv[-1] in scan_language_list() else "Auto"
+language = resolve_language()
 os.environ["language"] = language
 i18n = I18nAuto(language=language)
 from multiprocessing import cpu_count


### PR DESCRIPTION
## Summary

This PR extracts the duplicated language resolution logic into a shared helper.

The goal is to reduce duplication while preserving the existing behavior.

## Changes

- Introduce `resolve_language()` in `tools/i18n/i18n.py`.
- Use the helper in:
  - `webui.py`
  - `GPT_SoVITS/inference_webui.py`
- Add unit tests for the helper.

## Behavior

No functional changes are intended.

The existing behavior is preserved:

- the last supported CLI language argument still overrides the default language;
- `I18nAuto` continues to handle `Auto` and the existing fallback behavior;
- language propagation and environment handling remain unchanged.

## Validation

- Added unit tests for the helper.
- `pytest` passes.
- `py_compile` passes.