### PR TITLE
fix: correct type annotation and file encoding for cross-platform support

### DIFF
--- a/GPT_SoVITS/TTS_infer_pack/TextPreprocessor.py
+++ b/GPT_SoVITS/TTS_infer_pack/TextPreprocessor.py
@@ -31,7 +31,7 @@ def get_first(text: str) -> str:
     return text
 
 
-def merge_short_text_in_array(texts: str, threshold: int) -> list:
+def merge_short_text_in_array(texts: List[str], threshold: int) -> list:
     if (len(texts)) < 2:
         return texts
     result = []

--- a/GPT_SoVITS/text/chinese.py
+++ b/GPT_SoVITS/text/chinese.py
@@ -13,7 +13,7 @@ normalizer = lambda x: cn2an.transform(x, "an2cn")
 current_file_path = os.path.dirname(__file__)
 pinyin_to_symbol_map = {
     line.split("\t")[0]: line.strip().split("\t")[1]
-    for line in open(os.path.join(current_file_path, "opencpop-strict.txt")).readlines()
+    for line in open(os.path.join(current_file_path, "opencpop-strict.txt"), encoding="utf-8").readlines()
 }
 
 import jieba_fast

--- a/GPT_SoVITS/text/chinese2.py
+++ b/GPT_SoVITS/text/chinese2.py
@@ -14,7 +14,7 @@ normalizer = lambda x: cn2an.transform(x, "an2cn")
 current_file_path = os.path.dirname(__file__)
 pinyin_to_symbol_map = {
     line.split("\t")[0]: line.strip().split("\t")[1]
-    for line in open(os.path.join(current_file_path, "opencpop-strict.txt")).readlines()
+    for line in open(os.path.join(current_file_path, "opencpop-strict.txt"), encoding="utf-8").readlines()
 }
 
 import jieba_fast


### PR DESCRIPTION
1. **TextPreprocessor.py**: Fix type annotation `texts: str → texts: List[str]`.
   Both call sites pass a list returned by `str.split()`.
2. **chinese.py / chinese2.py**: Add `encoding="utf-8"` to `open()` call.
   On Windows, the default ANSI codepage cannot decode the UTF-8 `opencpop-strict.txt` (contains CJK characters),
   causing a `UnicodeDecodeError` at import time on module-level code.

**变更影响：**
修复了跨平台兼容性问题，使项目在Windows环境下也能正常导入依赖；
修正了类型注解错误，避免IDE类型检查报错。