### PR TITLE
feat(text): add Russian XSAMPA phoneme normalization

### DIFF
--- a/GPT_SoVITS/text/russian.py
+++ b/GPT_SoVITS/text/russian.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""Russian phoneme helpers.
+
+This module contains the checkpoint-facing normalization used to convert
+Epitran-style XSAMPA symbols into the compact Latin inventory expected by
+Russian GPT-SoVITS checkpoints.
+"""
+
+from __future__ import annotations
+
+
+_XSAMPA_BASE_MAP = {
+    "1": "I",
+    "@": "A",
+    "6": "A",
+    "s`": "S",
+    "S`": "S",
+}
+_ALLOWED_BASES = frozenset("ABDEFGIJKLMNOPRSTUVXZ")
+
+
+def normalize_xsampa_symbol(symbol: str) -> str:
+    """Normalize one Russian XSAMPA symbol to the checkpoint base inventory.
+
+    Epitran emits multi-character and modified symbols for Russian, including
+    palatalized consonants (for example ``d'``), long vowels, and ``s``` for
+    Russian ``ш`` (IPA ``ʂ``). Russian checkpoints use a collapsed uppercase
+    base inventory, so supported modifiers are removed after resolving known
+    multi-character symbols.
+
+    Raises:
+        ValueError: if the normalized symbol is outside the supported Russian
+            checkpoint inventory.
+    """
+
+    if not isinstance(symbol, str) or not symbol:
+        raise ValueError("Russian XSAMPA symbol must be a non-empty string")
+
+    normalized = _XSAMPA_BASE_MAP.get(symbol, symbol)
+    normalized = normalized.replace("'", "").replace(":", "").replace("\\", "")
+    normalized = _XSAMPA_BASE_MAP.get(normalized, normalized).upper()
+
+    if normalized not in _ALLOWED_BASES:
+        raise ValueError(f"Unsupported Russian XSAMPA symbol: {symbol!r}")
+    return normalized

--- a/tests/test_russian_phonemes.py
+++ b/tests/test_russian_phonemes.py
@@ -1,0 +1,28 @@
+import pytest
+
+from GPT_SoVITS.text.russian import normalize_xsampa_symbol
+
+
+@pytest.mark.parametrize(
+    ("symbol", "expected"),
+    [
+        ("d'", "D"),
+        ("n'", "N"),
+        ("r'", "R"),
+        ("l'", "L"),
+        ("a:", "A"),
+        ("1", "I"),
+        ("@", "A"),
+        ("6", "A"),
+        ("s`", "S"),
+        ("S`", "S"),
+    ],
+)
+def test_normalize_russian_xsampa_symbol(symbol, expected):
+    assert normalize_xsampa_symbol(symbol) == expected
+
+
+@pytest.mark.parametrize("symbol", ["", "?", "t_s", None])
+def test_normalize_russian_xsampa_symbol_rejects_unsupported_input(symbol):
+    with pytest.raises(ValueError, match="Russian XSAMPA|Unsupported Russian"):
+        normalize_xsampa_symbol(symbol)


### PR DESCRIPTION
## Summary

Add a small, isolated Russian XSAMPA normalization helper as an initial building block for Russian language support discussed in #2529.

## Changes

- add `GPT_SoVITS/text/russian.py` with `normalize_xsampa_symbol()`;
- normalize common Epitran-style Russian XSAMPA variants;
- map `1` to `I`, `@`/`6` to `A`, and `s``/`S`` to `S`;
- strip supported palatalization/length modifiers;
- reject unsupported symbols explicitly instead of silently falling back;
- add regression tests for supported and unsupported inputs.

## Scope

This PR does not claim complete Russian language support. It only contributes the checkpoint-facing phoneme normalization layer so the behavior can be reviewed independently.

Related to #2529.