### PR TITLE
Fix Fun-ASR-Nano Transformers requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ g2p_en
 torchaudio
 modelscope
 sentencepiece
-transformers>=4.43,<=4.50
+transformers>=4.51,<5
 peft<0.18.0
 chardet
 PyYAML


### PR DESCRIPTION
## Summary

- require a Qwen3-capable Transformers release for the Fun-ASR-Nano backend
- keep the dependency below Transformers 5 to avoid an untested major-version upgrade

## Root cause

GPT-SoVITS advertises `FunAudioLLM/Fun-ASR-Nano-2512`, whose bundled language model declares `model_type: qwen3`. The current `transformers>=4.43,<=4.50` constraint cannot resolve that architecture, so selecting Fun-ASR-Nano fails with `KeyError: qwen3` before transcription starts. Transformers 4.51 is the first release in the tested matrix that recognizes and instantiates Qwen3.

## Validation

- reproduced the failure against the real bundled Qwen3 config with Transformers 4.50.3
- passed Qwen3 config/model construction with Transformers 4.51.3 and 4.57.6
- passed GPT-SoVITS BERT masked-LM and HuBERT construction on both boundary versions
- resolved the full requirement pair to Transformers 4.57.6 and PEFT 0.17.1
- loaded FunASR 1.4.2 through `tools/asr/funasr_asr.py` and transcribed the official Chinese sample on CPU
- `python -m compileall tools/asr/funasr_asr.py` and `git diff --check`

Fixes #2823