### PR TITLE
fix: support Windows single GPU SoVITS training without DDP

### DIFF
--- a/GPT_SoVITS/s2_train.py
+++ b/GPT_SoVITS/s2_train.py
@@ -58,18 +58,22 @@ def main():
     os.environ["MASTER_ADDR"] = "localhost"
     os.environ["MASTER_PORT"] = str(randint(20000, 55555))
 
-    mp.spawn(
-        run,
-        nprocs=n_gpus,
-        args=(
-            n_gpus,
-            hps,
-        ),
-    )
+    if n_gpus == 1:
+        run(0, n_gpus, hps)
+    else:
+        mp.spawn(
+            run,
+            nprocs=n_gpus,
+            args=(
+                n_gpus,
+                hps,
+            ),
+        )
 
 
 def run(rank, n_gpus, hps):
     global global_step
+    use_ddp = torch.cuda.is_available() and n_gpus > 1
     if rank == 0:
         logger = utils.get_logger(hps.data.exp_dir)
         logger.info(hps)
@@ -77,12 +81,13 @@ def run(rank, n_gpus, hps):
         writer = SummaryWriter(log_dir=hps.s2_ckpt_dir)
         writer_eval = SummaryWriter(log_dir=os.path.join(hps.s2_ckpt_dir, "eval"))
 
-    dist.init_process_group(
-        backend="gloo" if os.name == "nt" or not torch.cuda.is_available() else "nccl",
-        init_method="env://?use_libuv=False",
-        world_size=n_gpus,
-        rank=rank,
-    )
+    if use_ddp:
+        dist.init_process_group(
+            backend="gloo" if os.name == "nt" else "nccl",
+            init_method="env://?use_libuv=False",
+            world_size=n_gpus,
+            rank=rank,
+        )
     torch.manual_seed(hps.train.seed)
     if torch.cuda.is_available():
         torch.cuda.set_device(rank)
@@ -196,10 +201,10 @@ def run(rank, n_gpus, hps):
         betas=hps.train.betas,
         eps=hps.train.eps,
     )
-    if torch.cuda.is_available():
+    if use_ddp:
         net_g = DDP(net_g, device_ids=[rank], find_unused_parameters=True)
         net_d = DDP(net_d, device_ids=[rank], find_unused_parameters=True)
-    else:
+    elif not torch.cuda.is_available():
         net_g = net_g.to(device)
         net_d = net_d.to(device)
 
@@ -232,14 +237,10 @@ def run(rank, n_gpus, hps):
         ):
             if rank == 0:
                 logger.info("loaded pretrained %s" % hps.train.pretrained_s2G)
+            model_g = net_g.module if hasattr(net_g, "module") else net_g
             print(
                 "loaded pretrained %s" % hps.train.pretrained_s2G,
-                net_g.module.load_state_dict(
-                    torch.load(hps.train.pretrained_s2G, map_location="cpu", weights_only=False)["weight"],
-                    strict=False,
-                )
-                if torch.cuda.is_available()
-                else net_g.load_state_dict(
+                model_g.load_state_dict(
                     torch.load(hps.train.pretrained_s2G, map_location="cpu", weights_only=False)["weight"],
                     strict=False,
                 ),
@@ -251,14 +252,11 @@ def run(rank, n_gpus, hps):
         ):
             if rank == 0:
                 logger.info("loaded pretrained %s" % hps.train.pretrained_s2D)
+            model_d = net_d.module if hasattr(net_d, "module") else net_d
             print(
                 "loaded pretrained %s" % hps.train.pretrained_s2D,
-                net_d.module.load_state_dict(
+                model_d.load_state_dict(
                     torch.load(hps.train.pretrained_s2D, map_location="cpu", weights_only=False)["weight"], strict=False
-                )
-                if torch.cuda.is_available()
-                else net_d.load_state_dict(
-                    torch.load(hps.train.pretrained_s2D, map_location="cpu", weights_only=False)["weight"],
                 ),
             )
 
@@ -476,9 +474,9 @@ def train_and_evaluate(rank, epoch, hps, nets, optims, schedulers, scaler, loade
                     }
                 )
 
-                # scalar_dict.update({"loss/g/{}".format(i): v for i, v in enumerate(losses_gen)})
-                # scalar_dict.update({"loss/d_r/{}".format(i): v for i, v in enumerate(losses_disc_r)})
-                # scalar_dict.update({"loss/d_g/{}".format(i): v for i, v in enumerate(losses_disc_g)})
+                # scalar_dict.update({"loss/g/{}".format(i): v for i, x in enumerate(losses_gen)})
+                # scalar_dict.update({"loss/d_r/{}".format(i): v for i, x in enumerate(losses_disc_r)})
+                # scalar_dict.update({"loss/d_g/{}".format(i): v for i, x in enumerate(losses_disc_g)})
                 image_dict = None
                 try:  ###Some people installed the wrong version of matplotlib.
                     image_dict = {
@@ -607,24 +605,14 @@ def evaluate(hps, generator, eval_loader, writer_eval):
                 ssl = ssl.to(device)
                 text, text_lengths = text.to(device), text_lengths.to(device)
             for test in [0, 1]:
-                y_hat, mask, *_ = (
-                    generator.module.infer(
-                        ssl,
-                        spec,
-                        spec_lengths,
-                        text,
-                        text_lengths,
-                        test=test,
-                    )
-                    if torch.cuda.is_available()
-                    else generator.infer(
-                        ssl,
-                        spec,
-                        spec_lengths,
-                        text,
-                        text_lengths,
-                        test=test,
-                    )
+                generator_to_infer = generator.module if hasattr(generator, "module") else generator
+                y_hat, mask, *_ = generator_to_infer.infer(
+                    ssl,
+                    spec,
+                    spec_lengths,
+                    text,
+                    text_lengths,
+                    test=test,
                 )
                 y_hat_lengths = mask.sum([1, 2]).long() * hps.data.hop_length
 


### PR DESCRIPTION
## 中文说明

### 问题

在 Windows 单 GPU 环境下，`GPT_SoVITS/s2_train.py` 当前仍会启动 `mp.spawn`、初始化 Gloo process group，并使用 `DistributedDataParallel`。在单 GPU 场景下这些步骤没有并行收益，还可能导致训练在第一步前后直接崩溃。

该问题与上游 issue `RVC-Boss/GPT-SoVITS#2806` 描述一致。

### 修改

- 单 GPU 时直接调用 `run(0, 1, hps)`，跳过 `mp.spawn`
- 仅在多 GPU CUDA 训练时初始化 distributed process group
- 仅在多 GPU 时使用 DDP 包装 `net_g` / `net_d`
- 预训练权重加载兼容 DDP 和非 DDP 模型
- `evaluate()` 兼容 wrapped / unwrapped generator
- 多 GPU 路径保持原有逻辑

### 实测环境

- Windows 11 x64
- NVIDIA GeForce RTX 4060 Laptop GPU，8 GB VRAM
- Python 3.10
- PyTorch 2.13.0+cu126
- CUDA runtime: 12.6
- GPT-SoVITS `main` commit: `48b1a016`
- 模型：v2ProPlus
- GPU：`0`
- 数据：313 条
- batch size：4
- epochs：8

### 实测结果

修复前，Windows 单 GPU SoVITS 训练会在 DDP/Gloo 路径中异常退出。

应用该修改后：

- SoVITS 完整训练 8 个 epoch
- 成功导出 e2 / e4 / e6 / e8 权重
- 未出现 OOM、NaN 或 native process crash

---

## English

### Problem

On Windows with a single GPU, `GPT_SoVITS/s2_train.py` still launches `mp.spawn`, initializes a Gloo process group, and wraps the models with `DistributedDataParallel`. This provides no parallelism benefit for a single GPU and can cause training to crash around the first step.

This matches the behavior described in upstream issue `RVC-Boss/GPT-SoVITS#2806`.

### Changes

- Run `run(0, 1, hps)` directly for single-GPU training instead of using `mp.spawn`
- Initialize the distributed process group only for multi-GPU CUDA training
- Wrap `net_g` / `net_d` with DDP only for multi-GPU training
- Make pretrained checkpoint loading work with both wrapped and unwrapped models
- Make `evaluate()` work with both wrapped and unwrapped generators
- Preserve the existing multi-GPU path

### Tested environment

- Windows 11 x64
- NVIDIA GeForce RTX 4060 Laptop GPU, 8 GB VRAM
- Python 3.10
- PyTorch 2.13.0+cu126
- CUDA runtime: 12.6
- GPT-SoVITS `main` commit: `48b1a016`
- Model: v2ProPlus
- GPU: `0`
- Dataset: 313 samples
- Batch size: 4
- Epochs: 8

### Result

Before this change, Windows single-GPU SoVITS training exited abnormally in the DDP/Gloo path.

After applying this change:

- SoVITS completed all 8 epochs
- e2 / e4 / e6 / e8 weights were exported successfully
- No OOM, NaN, or native process crash occurred

Related: RVC-Boss/GPT-SoVITS#2806